### PR TITLE
Fix marbl_in generation/copy for multi instance runs

### DIFF
--- a/BranchChangeLog
+++ b/BranchChangeLog
@@ -1,4 +1,15 @@
 ===============================================================================
+Tag Creator:  altuntas
+Developers:   altuntas
+Tag Date:     28 May 2019
+Tag Name:     pop2_cesm2_1_rel_n05
+Tag Summary:  Fix rpointer logic and marb_in gen for multi-instance runs
+
+Testing: aux_pop and aux_pop_MARBL (b4b)
+
+M       cime_config/buildnml
+
+===============================================================================
 Tag Creator:  klindsay
 Developers:   klindsay
 Tag Date:     12 Apr 2019

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -208,7 +208,10 @@ def buildnml(case, caseroot, compname):
 
             # marbl_in and marbl_diagnostics_operators
             if marbl_nt_build > 0:
-                _copy_file('marbl_in', confdir, rundir, inst_string)
+                if inst_string:
+                    _copy_file('marbl_in'+inst_string, confdir, rundir)
+                else:
+                    _copy_file('marbl_in', confdir, rundir)
                 _copy_file('marbl_diagnostics_operators', confdir, rundir)
 
             # tavg_contents file
@@ -256,7 +259,10 @@ def _construct_marbl_in(caseroot, ocn_grid, run_type, continue_run, ocn_bgc_conf
         sys.exit(1)
 
     # (iii) write settings file
-    MARBL_settings.write_settings_file(os.path.join(confdir, "marbl_in"))
+    if inst_string:
+        MARBL_settings.write_settings_file(os.path.join(confdir, "marbl_in"+inst_string))
+    else:
+        MARBL_settings.write_settings_file(os.path.join(confdir, "marbl_in"))
 
 ###############################################################################
 

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -208,10 +208,7 @@ def buildnml(case, caseroot, compname):
 
             # marbl_in and marbl_diagnostics_operators
             if marbl_nt_build > 0:
-                if inst_string:
-                    _copy_file('marbl_in'+inst_string, confdir, rundir)
-                else:
-                    _copy_file('marbl_in', confdir, rundir)
+                _copy_file('marbl_in'+inst_string, confdir, rundir)
                 _copy_file('marbl_diagnostics_operators', confdir, rundir)
 
             # tavg_contents file
@@ -259,10 +256,7 @@ def _construct_marbl_in(caseroot, ocn_grid, run_type, continue_run, ocn_bgc_conf
         sys.exit(1)
 
     # (iii) write settings file
-    if inst_string:
-        MARBL_settings.write_settings_file(os.path.join(confdir, "marbl_in"+inst_string))
-    else:
-        MARBL_settings.write_settings_file(os.path.join(confdir, "marbl_in"))
+    MARBL_settings.write_settings_file(os.path.join(confdir, "marbl_in"+inst_string))
 
 ###############################################################################
 


### PR DESCRIPTION
### Description of changes:

For multi-instance runs, buildnml tries to copy marbl_in+inst_str files from popconf to run directory which fails because buildnml creates a single marbl_in file in popconf directory. Error message from IRT_N3_PM3_Ld7.f19_g17.BHIST.cheyenne_intel.allactive-defaultio :

```
   Calling /gpfs/fs1/work/altuntas/cesm.sandboxes/cesm2.1-alphabranch/components/pop//cime_config/buildnml
     grep: marbl_in_0001: No such file or directory
     grep: marbl_in_0002: No such file or directory
     grep: marbl_in_0003: No such file or directory
```
 With this PR, a marbl_in+inst_str file is created for each instance in popconf and copied to rundir.


### Testing:
IRT_N3_PM3_Ld7.f19_g17.BHIST.cheyenne_intel.allactive-defaultio
SMS.f19_g17.BHIST.cheyenne_intel.allactive-defaultio
SMS.f19_g17.C.cheyenne_intel
SMS.T62_g17.C1850ECO.cheyenne_intel

(all builds passed, some runs pending)

Fixes [POP2 Github issue #] n/a

