### PR TITLE
Fixes BSF diagnostics for large NTHRDS and NTASKS

### DIFF
--- a/source/diag_bsf.F90
+++ b/source/diag_bsf.F90
@@ -885,6 +885,10 @@
 
    call gather_global (WORK1, KMT, master_task,distrb_clinic)
 
+   ! Set WORK1 (i.e., KMT) to zero where negative. (Eliminated land blocks get filled
+   ! with undefined_nf_int, but the below code block assumes KMT >= 0.)
+   where (WORK1<0) WORK1 = 0
+
    error_code = 0
 
    if ( my_task == master_task ) then

--- a/source/diag_bsf.F90
+++ b/source/diag_bsf.F90
@@ -885,9 +885,9 @@
 
    call gather_global (WORK1, KMT, master_task,distrb_clinic)
 
-   ! Set WORK1 (i.e., KMT) to zero where negative. (Eliminated land blocks get filled
-   ! with undefined_nf_int, but the below code block assumes KMT >= 0.)
-   where (WORK1<0) WORK1 = 0
+   ! Set WORK1 (i.e., KMT) to zero in eliminated land blocks, since
+   ! below code block expects land cells to be KMT=0.
+   where (WORK1.eq.undefined_nf_int) WORK1 = 0
 
    error_code = 0
 


### PR DESCRIPTION
### Description of changes:

With this PR, the KMT values of eliminated land blocks are set to zero (instead of ```undefined_nf_int```) in ```island_mask_diag_bsf``` subroutine. The change is needed because the logic in ```island_mask_diag_bsf``` assumes all land cells are KMT=0.

### Testing:
 
Test case/suite: SMS_Lm1.f19_g17.B1850
Test status: bit for bit
Fixes: BSF diagnostics for large NTHRDS and NTASKS