### PR TITLE
Fix bad compset name in cesm2_1 testlist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# gitignore for POP2
+
+# directories checked out by manage_externals, and other files created
+# by manage_externals
+manage_externals.log
+externals/MARBL
+externals/CVMix
+
+# binary files
+*.nc
+
+# editor files
+*.swp
+*~
+
+# mac files
+.DS_Store
+
+# cime_config
+buildnmlc
+buildcppc
+
+# misc
+*.pyc
+*.gz

--- a/BranchChangeLog
+++ b/BranchChangeLog
@@ -1,15 +1,18 @@
 ===============================================================================
 Tag Creator:  mlevy
 Developers:   mlevy
-Tag Date:     6 Feb 2020
+Tag Date:     24 Feb 2020
 Tag Name:     pop2_cesm2_1_rel_n10
 Tag Summary:  Correct compset for GOMIP with JRA
 
               Also, I added .gitignore (identical to the version on master)
+              and fixed GIAF_JRA_HR definition.
 
 Testing: Verified GOMIPECOIAF_JRA tests failed with "compset not found" and then
-         verified the updated testlist with GOMIPECOIAF_JRA-1p4-2018 worked
+         verified the updated testlist with GOMIPECOIAF_JRA-1p4-2018 worked.
+         Also verified that I can create a case with GIAF_JRA_HR.
 
+M       cime_config/config_compsets.xml
 M       cime_config/testdefs/testlist_pop.xml
 A       .gitignore
 

--- a/BranchChangeLog
+++ b/BranchChangeLog
@@ -1,6 +1,21 @@
 ===============================================================================
 Tag Creator:  mlevy
 Developers:   mlevy
+Tag Date:     6 Feb 2020
+Tag Name:     pop2_cesm2_1_rel_n10
+Tag Summary:  Correct compset for GOMIP with JRA
+
+              Also, I added .gitignore (identical to the version on master)
+
+Testing: Verified GOMIPECOIAF_JRA tests failed with "compset not found" and then
+         verified the updated testlist with GOMIPECOIAF_JRA-1p4-2018 worked
+
+M       cime_config/testdefs/testlist_pop.xml
+A       .gitignore
+
+===============================================================================
+Tag Creator:  mlevy
+Developers:   mlevy
 Tag Date:     21 Jan 2020
 Tag Name:     pop2_cesm2_1_rel_n09
 Tag Summary:  Add BranchChangeLog update

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -124,7 +124,7 @@
   <compset>
     <!-- latest JRA forcing -->
     <alias>GIAF_JRA_HR</alias>
-    <lname>2000_DATM%JRA-1p4-2018-1p4-2018_SLND_CICE_POP2_DROF%JRA-1p4-2018_SGLC_SWAV</lname>
+    <lname>2000_DATM%JRA-1p4-2018_SLND_CICE_POP2_DROF%JRA-1p4-2018_SGLC_SWAV</lname>
   </compset>
 
   <compset>

--- a/cime_config/testdefs/testlist_pop.xml
+++ b/cime_config/testdefs/testlist_pop.xml
@@ -527,7 +527,7 @@
       <machine name="cheyenne" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
-  <test name="SMS_D_Ld2" grid="TL319_g17" compset="GOMIPECOIAF_JRA" testmods="pop/omip">
+  <test name="SMS_D_Ld2" grid="TL319_g17" compset="GOMIPECOIAF_JRA-1p4-2018" testmods="pop/omip">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
       <machine name="cheyenne" compiler="intel" category="aux_pop"/>


### PR DESCRIPTION
### Description of changes:

`GOMIPECOIAF_JRA` was renamed to `GOMIPECOIAF_JRA-1p4-2018` in #14 but the testlist was not updated. (Also added `.gitignore` from `master`)


### Testing:
 
Test case/suite: generated all tests for `aux_pop` on cheyenne, verified that the `GOMIPECOIAF_JRA` failed but `GOMIPECOIAF_JRA-1p4-2018` was acceptable.
Test status: N/A (didn't actually run the tests, just created the cases for the tests)

No user interface (namelist or namelist defaults) changes

