### PR TITLE
Convert netcdf-4 file to cdf5, update nml defaults

### DIFF
--- a/bld/namelist_files/namelist_defaults_pop.xml
+++ b/bld/namelist_files/namelist_defaults_pop.xml
@@ -1444,17 +1444,17 @@
 <ndep_shr_stream_year_first ocn_transient="CORE2_OMIP">1637</ndep_shr_stream_year_first> <!-- 1948-(6-1)*(2009-1948+1)-1 -->
 <ndep_shr_stream_year_last  ocn_transient="CORE2_OMIP">2010</ndep_shr_stream_year_last>
 <ndep_shr_stream_year_align ocn_transient="CORE2_OMIP">0</ndep_shr_stream_year_align>
-<ndep_shr_stream_file ocn_grid="gx3v7" ocn_transient="CORE2_OMIP">ocn/pop/gx3v7/forcing/ndep_ocn_omip_w_nhx_emis_gx3v7_1637-2019_c190522.nc</ndep_shr_stream_file>
-<ndep_shr_stream_file ocn_grid="gx1v6" ocn_transient="CORE2_OMIP">ocn/pop/gx1v6/forcing/ndep_ocn_omip_w_nhx_emis_gx1v6_1637-2019_c190522.nc</ndep_shr_stream_file>
-<ndep_shr_stream_file ocn_grid="gx1v7" ocn_transient="CORE2_OMIP">ocn/pop/gx1v6/forcing/ndep_ocn_omip_w_nhx_emis_gx1v6_1637-2019_c190522.nc</ndep_shr_stream_file>
+<ndep_shr_stream_file ocn_grid="gx3v7" ocn_transient="CORE2_OMIP">ocn/pop/gx3v7/forcing/ndep_ocn_omip_w_nhx_emis_gx3v7_1637-2019_c200324.nc</ndep_shr_stream_file>
+<ndep_shr_stream_file ocn_grid="gx1v6" ocn_transient="CORE2_OMIP">ocn/pop/gx1v6/forcing/ndep_ocn_omip_w_nhx_emis_gx1v6_1637-2019_c200324.nc</ndep_shr_stream_file>
+<ndep_shr_stream_file ocn_grid="gx1v7" ocn_transient="CORE2_OMIP">ocn/pop/gx1v6/forcing/ndep_ocn_omip_w_nhx_emis_gx1v6_1637-2019_c200324.nc</ndep_shr_stream_file>
 
 <ndep_data_type ocn_transient="JRA_OMIP">shr_stream</ndep_data_type>
 <ndep_shr_stream_year_first ocn_transient="JRA_OMIP">1652</ndep_shr_stream_year_first> <!-- 1958-(6-1)*(2018-1958+1)-1 -->
 <ndep_shr_stream_year_last  ocn_transient="JRA_OMIP">2019</ndep_shr_stream_year_last>
 <ndep_shr_stream_year_align ocn_transient="JRA_OMIP">0</ndep_shr_stream_year_align>
-<ndep_shr_stream_file ocn_grid="gx3v7" ocn_transient="JRA_OMIP">ocn/pop/gx3v7/forcing/ndep_ocn_omip_w_nhx_emis_gx3v7_1637-2019_c190522.nc</ndep_shr_stream_file>
-<ndep_shr_stream_file ocn_grid="gx1v6" ocn_transient="JRA_OMIP">ocn/pop/gx1v6/forcing/ndep_ocn_omip_w_nhx_emis_gx1v6_1637-2019_c190522.nc</ndep_shr_stream_file>
-<ndep_shr_stream_file ocn_grid="gx1v7" ocn_transient="JRA_OMIP">ocn/pop/gx1v6/forcing/ndep_ocn_omip_w_nhx_emis_gx1v6_1637-2019_c190522.nc</ndep_shr_stream_file>
+<ndep_shr_stream_file ocn_grid="gx3v7" ocn_transient="JRA_OMIP">ocn/pop/gx3v7/forcing/ndep_ocn_omip_w_nhx_emis_gx3v7_1637-2019_c200324.nc</ndep_shr_stream_file>
+<ndep_shr_stream_file ocn_grid="gx1v6" ocn_transient="JRA_OMIP">ocn/pop/gx1v6/forcing/ndep_ocn_omip_w_nhx_emis_gx1v6_1637-2019_2003242.nc</ndep_shr_stream_file>
+<ndep_shr_stream_file ocn_grid="gx1v7" ocn_transient="JRA_OMIP">ocn/pop/gx1v6/forcing/ndep_ocn_omip_w_nhx_emis_gx1v6_1637-2019_c200324.nc</ndep_shr_stream_file>
 
 <ndep_data_type ocn_transient="1850-2000">shr_stream</ndep_data_type>
 <ndep_shr_stream_year_first ocn_transient="1850-2000">1849</ndep_shr_stream_year_first>
@@ -1632,7 +1632,7 @@
 
 <init_ecosys_init_file ocn_grid="gx3v7">ocn/pop/gx3v7/ic/ecosys_jan_IC_gx3v7_20180308.nc</init_ecosys_init_file>
 <init_ecosys_init_file ocn_grid="gx1v6">ocn/pop/gx1v6/ic/ecosys_jan_IC_gx1v6_20180308.nc</init_ecosys_init_file>
-<init_ecosys_init_file ocn_grid="gx1v7">ocn/pop/gx1v6/ic/ecosys_jan_IC_omip_POP_gx1v7_c190615.nc</init_ecosys_init_file>
+<init_ecosys_init_file ocn_grid="gx1v7">ocn/pop/gx1v6/ic/ecosys_jan_IC_omip_POP_gx1v7_c200323.nc</init_ecosys_init_file>
 <init_ecosys_init_file ocn_grid="gx1v7" ocn_bgc_config="cesm2.0">ocn/pop/gx1v6/ic/ecosys_jan_IC_gx1v6_20180308.nc</init_ecosys_init_file>
 
 <init_ecosys_init_file_fmt>nc</init_ecosys_init_file_fmt>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -48,7 +48,7 @@
   </compset>
 
   <compset>
-    <!-- GIAF_JRA from CESM 2.1.1 -->
+    <!-- C_JRA from CESM 2.1.1 -->
     <alias>C_JRA-1p3-2016</alias>
     <lname>2000_DATM%JRA_SLND_DICE%SSMI_POP2_DROF%JRA_SGLC_WW3</lname>
   </compset>
@@ -60,7 +60,7 @@
   </compset>
 
   <compset>
-    <!-- GIAF_JRA from CESM 2.1.1 -->
+    <!-- C_JRA_HR from CESM 2.1.1 -->
     <alias>C_JRA-1p3-2016_HR</alias>
     <lname>2000_DATM%JRA_SLND_DICE%SSMI_POP2_DROF%JRA_SGLC_SWAV</lname>
   </compset>


### PR DESCRIPTION
### Description of changes:

`ndep_shr_stream_file` and `init_ecosys_init_file` were both, in some instances,
reading a netcdf-4 file, which is not compatible with pnetcdf and can
occasionally cause issues in PIO. I converted those files to cdf5 and updated
the namelist defaults file to read the new versions.

This matches the changes to default files included in #25 so `cesm2_1_x_rel` and `master`
will continue to use the same file (something in the CESM 2.2 build caused PIO to balk at reading netcdf-4 files; while that is not currently an issue in CESM 2.1, it could be in a future release)

### Testing:
 
Test case/suite: `aux_pop` and `aux_pop_MARBL` on cheyenne
Test status: bit for bit

Fixes N/A

User interface (namelist or namelist defaults) changes?
-- namelist changes for all runs using gx1v7 resolution AND with `ecosys_on = .true.`

