### PR TITLE
Update dt_count for RCP extensions

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -515,7 +515,7 @@ add_default($nl, 'dt_option');
 my $time_mix_opt = $nl->get_value('time_mix_opt');
 $time_mix_opt =~ s/^\s+//;
 $time_mix_opt =~ s/\s+$//;
-add_default($nl, 'dt_count','ocn_coupling'=>"$OCN_COUPLING",'ocn_onedim'=>"$OCN_ONEDIM", 'time_mix'=>"$time_mix_opt");
+add_default($nl, 'dt_count','ocn_coupling'=>"$OCN_COUPLING",'ocn_onedim'=>"$OCN_ONEDIM", 'time_mix'=>"$time_mix_opt", 'ocn_transient'=>"$OCN_TRANSIENT");
 
 add_default($nl, 'impcor');
 add_default($nl, 'laccel');

--- a/bld/namelist_files/namelist_defaults_pop.xml
+++ b/bld/namelist_files/namelist_defaults_pop.xml
@@ -56,6 +56,8 @@
 <dt_count ocn_grid="gx1v6"  ocn_onedim="TRUE">46</dt_count>
 <dt_count ocn_grid="gx1v7"  > 24</dt_count>
 <dt_count ocn_grid="gx1v7"  ocn_onedim="TRUE">46</dt_count>
+<dt_count ocn_grid="gx1v7"  ocn_transient="ssp534ext">48</dt_count>
+<dt_count ocn_grid="gx1v7"  ocn_transient="ssp585ext">48</dt_count>
 <dt_count ocn_grid="tx1v1"  > 24</dt_count>
 <dt_count ocn_grid="tx0.1v2">300</dt_count>
 <dt_count ocn_grid="tx0.1v2" ocn_coupling="partial">500</dt_count>
@@ -1504,6 +1506,8 @@
 <ndep_shr_stream_file ocn_grid="gx1v6" ocn_transient="ssp370">ocn/pop/gx1v6/forcing/ndep_ocn_ssp370_w_nhx_emis_gx1v6_c190412.nc</ndep_shr_stream_file>
 <ndep_shr_stream_file ocn_grid="gx1v7" ocn_transient="ssp370">ocn/pop/gx1v6/forcing/ndep_ocn_ssp370_w_nhx_emis_gx1v6_c190412.nc</ndep_shr_stream_file>
 
+<ndep_data_type ocn_transient="ssp534ext">driver</ndep_data_type>
+
 <ndep_data_type ocn_transient="ssp585">shr_stream</ndep_data_type>
 <ndep_shr_stream_year_first ocn_transient="ssp585">2014</ndep_shr_stream_year_first>
 <ndep_shr_stream_year_last  ocn_transient="ssp585">2101</ndep_shr_stream_year_last>
@@ -1511,6 +1515,8 @@
 <ndep_shr_stream_file ocn_grid="gx3v7" ocn_transient="ssp585">ocn/pop/gx3v7/forcing/ndep_ocn_ssp585_w_nhx_emis_gx3v7_c190212.nc</ndep_shr_stream_file>
 <ndep_shr_stream_file ocn_grid="gx1v6" ocn_transient="ssp585">ocn/pop/gx1v6/forcing/ndep_ocn_ssp585_w_nhx_emis_gx1v6_c190212.nc</ndep_shr_stream_file>
 <ndep_shr_stream_file ocn_grid="gx1v7" ocn_transient="ssp585">ocn/pop/gx1v6/forcing/ndep_ocn_ssp585_w_nhx_emis_gx1v6_c190212.nc</ndep_shr_stream_file>
+
+<ndep_data_type ocn_transient="ssp585ext">driver</ndep_data_type>
 
 <riv_flux_shr_stream_file ocn_grid="gx3v7">ocn/pop/gx3v7/forcing/riv_nut.gnews_gnm.gx3v7_nnsm_e1000r500.20180511.nc</riv_flux_shr_stream_file>
 <riv_flux_shr_stream_file ocn_grid="gx1v6">ocn/pop/gx1v7/forcing/riv_nut.gnews_gnm.gx1v7_nnsm_e1000r300.20170425.nc</riv_flux_shr_stream_file>

--- a/bld/namelist_files/namelist_defaults_pop.xml
+++ b/bld/namelist_files/namelist_defaults_pop.xml
@@ -1505,8 +1505,6 @@
 <ndep_shr_stream_file ocn_grid="gx1v6" ocn_transient="ssp370">ocn/pop/gx1v6/forcing/ndep_ocn_ssp370_w_nhx_emis_gx1v6_c190412.nc</ndep_shr_stream_file>
 <ndep_shr_stream_file ocn_grid="gx1v7" ocn_transient="ssp370">ocn/pop/gx1v6/forcing/ndep_ocn_ssp370_w_nhx_emis_gx1v6_c190412.nc</ndep_shr_stream_file>
 
-<ndep_data_type ocn_transient="ssp534ext">driver</ndep_data_type>
-
 <ndep_data_type ocn_transient="ssp585">shr_stream</ndep_data_type>
 <ndep_shr_stream_year_first ocn_transient="ssp585">2014</ndep_shr_stream_year_first>
 <ndep_shr_stream_year_last  ocn_transient="ssp585">2101</ndep_shr_stream_year_last>
@@ -1514,8 +1512,6 @@
 <ndep_shr_stream_file ocn_grid="gx3v7" ocn_transient="ssp585">ocn/pop/gx3v7/forcing/ndep_ocn_ssp585_w_nhx_emis_gx3v7_c190212.nc</ndep_shr_stream_file>
 <ndep_shr_stream_file ocn_grid="gx1v6" ocn_transient="ssp585">ocn/pop/gx1v6/forcing/ndep_ocn_ssp585_w_nhx_emis_gx1v6_c190212.nc</ndep_shr_stream_file>
 <ndep_shr_stream_file ocn_grid="gx1v7" ocn_transient="ssp585">ocn/pop/gx1v6/forcing/ndep_ocn_ssp585_w_nhx_emis_gx1v6_c190212.nc</ndep_shr_stream_file>
-
-<ndep_data_type ocn_transient="ssp585ext">driver</ndep_data_type>
 
 <riv_flux_shr_stream_file ocn_grid="gx3v7">ocn/pop/gx3v7/forcing/riv_nut.gnews_gnm.gx3v7_nnsm_e1000r500.20180511.nc</riv_flux_shr_stream_file>
 <riv_flux_shr_stream_file ocn_grid="gx1v6">ocn/pop/gx1v7/forcing/riv_nut.gnews_gnm.gx1v7_nnsm_e1000r300.20170425.nc</riv_flux_shr_stream_file>

--- a/bld/namelist_files/namelist_defaults_pop.xml
+++ b/bld/namelist_files/namelist_defaults_pop.xml
@@ -1513,6 +1513,22 @@
 <ndep_shr_stream_file ocn_grid="gx1v6" ocn_transient="ssp585">ocn/pop/gx1v6/forcing/ndep_ocn_ssp585_w_nhx_emis_gx1v6_c190212.nc</ndep_shr_stream_file>
 <ndep_shr_stream_file ocn_grid="gx1v7" ocn_transient="ssp585">ocn/pop/gx1v6/forcing/ndep_ocn_ssp585_w_nhx_emis_gx1v6_c190212.nc</ndep_shr_stream_file>
 
+<ndep_data_type ocn_transient="ssp534ext">shr_stream</ndep_data_type>
+<ndep_shr_stream_year_first ocn_transient="ssp534ext">2100</ndep_shr_stream_year_first>
+<ndep_shr_stream_year_last  ocn_transient="ssp534ext">2300</ndep_shr_stream_year_last>
+<ndep_shr_stream_year_align ocn_transient="ssp534ext">2100</ndep_shr_stream_year_align>
+<ndep_shr_stream_file ocn_grid="gx3v7" ocn_transient="ssp534ext">ocn/pop/gx3v7/forcing/ndep_ocn_ssp534osext_w_nhx_emis_gx3v7_c200629.nc</ndep_shr_stream_file>
+<ndep_shr_stream_file ocn_grid="gx1v6" ocn_transient="ssp534ext">ocn/pop/gx1v6/forcing/ndep_ocn_ssp534osext_w_nhx_emis_gx1v6_c200629.nc</ndep_shr_stream_file>
+<ndep_shr_stream_file ocn_grid="gx1v7" ocn_transient="ssp534ext">ocn/pop/gx1v6/forcing/ndep_ocn_ssp534osext_w_nhx_emis_gx1v6_c200629.nc</ndep_shr_stream_file>
+
+<ndep_data_type ocn_transient="ssp585ext">shr_stream</ndep_data_type>
+<ndep_shr_stream_year_first ocn_transient="ssp585ext">2100</ndep_shr_stream_year_first>
+<ndep_shr_stream_year_last  ocn_transient="ssp585ext">2300</ndep_shr_stream_year_last>
+<ndep_shr_stream_year_align ocn_transient="ssp585ext">2100</ndep_shr_stream_year_align>
+<ndep_shr_stream_file ocn_grid="gx3v7" ocn_transient="ssp585ext">ocn/pop/gx3v7/forcing/ndep_ocn_ssp585ext_w_nhx_emis_gx3v7_c200629.nc</ndep_shr_stream_file>
+<ndep_shr_stream_file ocn_grid="gx1v6" ocn_transient="ssp585ext">ocn/pop/gx1v6/forcing/ndep_ocn_ssp585ext_w_nhx_emis_gx1v6_c200629.nc</ndep_shr_stream_file>
+<ndep_shr_stream_file ocn_grid="gx1v7" ocn_transient="ssp585ext">ocn/pop/gx1v6/forcing/ndep_ocn_ssp585ext_w_nhx_emis_gx1v6_c200629.nc</ndep_shr_stream_file>
+
 <riv_flux_shr_stream_file ocn_grid="gx3v7">ocn/pop/gx3v7/forcing/riv_nut.gnews_gnm.gx3v7_nnsm_e1000r500.20180511.nc</riv_flux_shr_stream_file>
 <riv_flux_shr_stream_file ocn_grid="gx1v6">ocn/pop/gx1v7/forcing/riv_nut.gnews_gnm.gx1v7_nnsm_e1000r300.20170425.nc</riv_flux_shr_stream_file>
 <riv_flux_shr_stream_file ocn_grid="gx1v7">ocn/pop/gx1v7/forcing/riv_nut.gnews_gnm.gx1v7_nnsm_e1000r300.20170425.nc</riv_flux_shr_stream_file>

--- a/bld/namelist_files/namelist_defaults_pop.xml
+++ b/bld/namelist_files/namelist_defaults_pop.xml
@@ -56,7 +56,6 @@
 <dt_count ocn_grid="gx1v6"  ocn_onedim="TRUE">46</dt_count>
 <dt_count ocn_grid="gx1v7"  > 24</dt_count>
 <dt_count ocn_grid="gx1v7"  ocn_onedim="TRUE">46</dt_count>
-<dt_count ocn_grid="gx1v7"  ocn_transient="ssp534ext">48</dt_count>
 <dt_count ocn_grid="gx1v7"  ocn_transient="ssp585ext">48</dt_count>
 <dt_count ocn_grid="tx1v1"  > 24</dt_count>
 <dt_count ocn_grid="tx0.1v2">300</dt_count>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -138,7 +138,7 @@
 
   <entry id="OCN_TRANSIENT">
     <type>char</type>
-    <valid_values>unset,CORE2_NYF,CORE2,CORE2_OMIP,JRA,JRA_OMIP,1850-2000,rcp4.5,rcp8.5,ssp126,ssp245,ssp370,ssp585</valid_values>
+    <valid_values>unset,CORE2_NYF,CORE2,CORE2_OMIP,JRA,JRA_OMIP,1850-2000,rcp4.5,rcp8.5,ssp126,ssp245,ssp370,ssp534ext,ssp585,ssp585ext</valid_values>
     <default_value>unset</default_value>
     <values>
       <value compset="DATM%NYF">CORE2_NYF</value>
@@ -153,7 +153,9 @@
       <value compset="^SSP126_CAM">ssp126</value>
       <value compset="^SSP245_CAM">ssp245</value>
       <value compset="^SSP370_CAM">ssp370</value>
+      <value compset="^SSP534EXT_CAM">ssp534ext</value>
       <value compset="^SSP585_CAM">ssp585</value>
+      <value compset="^SSP585EXT_CAM">ssp585ext</value>
     </values>
     <group>run_component_pop</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
### Description of changes:

Provide support for new `SSP534EXT` and `SSP585EXT` compsets -- the main goal was to provide a mechanism to set `dt_count=48` by default in the SSP585 extension.

### Testing:
 
I've provided branch tags to Mike Mills et al, who are testing the new compsets and think everything looks okay

Test case/suite: None
Test status: bit-for-bit

Fixes [POP2 Github issue #] N/A

User interface (namelist or namelist defaults) changes?

****

I have two concerns relating to the robustness of this PR:

1. Setting `dt_count` via

   ```
   <dt_count ocn_grid="gx1v7"  ocn_transient="ssp585ext">48</dt_count>
   ```

   seems clunky, in the sense that it ignores other variables that might affect `dt_count`. In fact, I am confused why this value for `dt_count` wins out over

   ```
   <dt_count ocn_ncpl="24" time_mix="robert"  ocn_grid="gx1v7">24</dt_count>
   ```

   The former matches 2 out of 2 attributes, while the latter appears to matches 3 out of 3 and yet `dt_count` is set to 48 rather than 24. I think this is indicative of a bug in how `time_mix` is being passed to namelist defaults, and that fixing said bug will change the behavior in the new compset.

1. The variables that depend on `ocn_transient="ssp585"` are limited to some options in the `abio` tracer module (`abio_atm_d14c_filename`, `abio_atm_co2_opt`, `abio_atm_d14c_opt`), some options in the `ciso` tracer module (`ciso_atm_d13c_opt`, `ciso_atm_d14c_opt`, `ciso_atm_d13c_filename`, and `ciso_atm_d14c_filename`), and `ndep` settings in the `ecosys` tracer module. It looks like `ssp534` is not used at all in the namelist defaults file, so I don't know how the 2015-2100 portion of that run was configured.

   I have not done anything to support `abio` or `ciso` in this new compset, and set `ndep_data_type="driver"` for both of the ssp extension compsets. This is a departure from SSP585, which uses `shr_stream` to read in a dataset containing 88 years of data.