### PR TITLE
Langmuir turbulence induced entrainment 

### DIFF
--- a/Externals_POP.cfg
+++ b/Externals_POP.cfg
@@ -1,5 +1,5 @@
 [CVMix]
-tag = v0.93-beta
+tag = v0.97b-beta
 protocol = git
 repo_url = https://github.com/CVMix/CVMix-src
 local_path = externals/CVMix

--- a/Externals_POP.cfg
+++ b/Externals_POP.cfg
@@ -1,5 +1,5 @@
 [CVMix]
-tag = v0.97b-beta
+tag = v0.98-beta
 protocol = git
 repo_url = https://github.com/CVMix/CVMix-src
 local_path = externals/CVMix

--- a/bld/namelist_files/namelist_definition_pop.xml
+++ b/bld/namelist_files/namelist_definition_pop.xml
@@ -2254,7 +2254,8 @@ Default: .true.
 id="langmuir_opt"
 type="char*256"
 category="Vertical Mixing (KPP)"
-group="vmix_kpp_nml" >
+group="vmix_kpp_nml"
+valid_values="null,vr12-ma,lf17" >
 Langmuir turbulence parameterization option.
 
 Valid Values: 'null', 'vr12-ma', 'lf17'

--- a/bld/namelist_files/namelist_definition_pop.xml
+++ b/bld/namelist_files/namelist_definition_pop.xml
@@ -117,7 +117,7 @@ type="char*256"
 category="Domain"
 group="domain_nml"
 valid_values="cyclic,closed,tripole" >
-Selector for type of boundary used in the logical north-south direction for global domain. 
+Selector for type of boundary used in the logical north-south direction for global domain.
 
 Valid Values: 'cyclic', 'closed', 'tripole'
 Default: 'closed'
@@ -256,7 +256,7 @@ id="accel_file"
 type="char*256"
 category="Time Management"
 group="time_manager_nml" >
-File containing vertical profile of timestep acceleration factors. 
+File containing vertical profile of timestep acceleration factors.
 
 Default: Set by CESM scripts based on ocean grid
 </entry>
@@ -267,7 +267,7 @@ type="real"
 category="Time Management"
 group="time_manager_nml" >
 Factor to multiply momentum timestep in order to set the momentum timestep to a
-value different from the tracer timestep.  
+value different from the tracer timestep.
 
 Default: 1.0
 </entry>
@@ -322,7 +322,7 @@ type="integer"
 category="Time Management"
 group="time_manager_nml" >
 Minutes at the start of the experiment. iminute0 remains fixed over the course of
-the integration; it does not change if experiment is continued. 
+the integration; it does not change if experiment is continued.
 
 Default: 0
 </entry>
@@ -601,7 +601,7 @@ type="char*256"
 category="Grid"
 group="grid_nml"
 input_pathname="abs" >
-Name of the input file containing integer region number at each horizontal gridpoint. 
+Name of the input file containing integer region number at each horizontal gridpoint.
 
 Default: Set by CESM scripts based on ocean grid
 </entry>
@@ -611,9 +611,9 @@ id="region_info_file"
 type="char*256"
 category="Grid"
 group="grid_nml" >
-Name of the input file containing integer region identification numbers at each gridpoint. 
+Name of the input file containing integer region identification numbers at each gridpoint.
 
-The information in this file associates region ids with a region name; a negative region id 
+The information in this file associates region ids with a region name; a negative region id
 indicates a marginal sea.
 
 Default: Set by CESM scripts based on ocean grid
@@ -780,7 +780,7 @@ category="Initialization"
 group="init_ts_nml"
 input_pathname="abs" >
 Name of the input file containing ocean initial conditions.
-Contents of this file depend on init_ts_option. If luse_pointer_files = .true., and 
+Contents of this file depend on init_ts_option. If luse_pointer_files = .true., and
 init_ts_option is 'ccsm_continue', 'ccsm_branch', or 'ccsm_hybrid', then
 init_ts_file is ignored and POP reads the file specified in the ocean rpointer files.
 
@@ -804,14 +804,14 @@ id="init_ts_suboption"
 type="char*256"
 category="Initialization"
 group="init_ts_nml" >
-Suboption for initializing temperature and salinity. See CESM documentation. 
+Suboption for initializing temperature and salinity. See CESM documentation.
 This option should only be used by experts.
 
 If init_ts_suboption = 'spunup', then init_ts_option is set (internally) to 'ccsm_startup_spunup';
 otherwise, this option has no effect. If the spunup suboption is selected, the model T,S are
-initialized from the specified input file, but velocities are initialized to zero, as in 
+initialized from the specified input file, but velocities are initialized to zero, as in
 a 'ccsm_startup' run.
-This option should only be used by experts. 
+This option should only be used by experts.
 
 Default: 'null'
 </entry>
@@ -839,12 +839,12 @@ Valid Values: 'bin', 'nc'
 Default: 'nc'
 </entry>
 
-<entry 
+<entry
 id="init_ts_perturb"
 type="real"
 category="Initialization"
 group="init_ts_nml">
-init_ts_perturb perturbation for ts. 
+init_ts_perturb perturbation for ts.
 
 Default: 1.0e-3
 </entry>
@@ -923,7 +923,7 @@ id="diag_transport_file"
 type="char*256"
 category="Model Diagnostics"
 group="diagnostics_nml" >
-Name of the file that contains information for choosing fields for output. 
+Name of the file that contains information for choosing fields for output.
 (the "transport_contents" file name)
 
 Default: Set by CESM scripts based on ocean grid
@@ -1010,7 +1010,7 @@ id="lrf_print_budget_term_by_term"
 type="logical"
 category="Diagnostics (Budgets)"
 group="budget_diagnostics_nml" >
-Flag to control the printing Robert-filter budget terms in a human-eye-friendly manner. 
+Flag to control the printing Robert-filter budget terms in a human-eye-friendly manner.
 
 Default: .false.
 </entry>
@@ -1105,7 +1105,7 @@ type="logical"
 category="Restart"
 group="restart_nml" >
 Flag to  apply correction to pressure upon restart.
-If .true., surface pressure is modified to correct for an error due to (possible) different timestep. 
+If .true., surface pressure is modified to correct for an error due to (possible) different timestep.
 Use .false. for exact restart.
 
 Default: .false.
@@ -1117,7 +1117,7 @@ type="char*256"
 category="Restart"
 group="restart_nml"
 valid_values="nstep,nday,nyear,date" >
-Units of time for restart_start. Take restart_start units 
+Units of time for restart_start. Take restart_start units
 prior to beginning the writing of regular restart files.
 
 Default: 'nstep'
@@ -1305,7 +1305,7 @@ id="convergenceCheckStart"
 type="integer"
 category="Barotropic Mode Solvers"
 group="solvers" >
-Start checking for convergence after convergenceCheckStart steps 
+Start checking for convergence after convergenceCheckStart steps
 (starting step number of convergence checking).
 
 Default: 60
@@ -1331,7 +1331,7 @@ id="preconditionerFile"
 type="char*256"
 category="Barotropic Mode Solvers"
 group="solvers" >
-File containing preconditioner coefficients for solver; 
+File containing preconditioner coefficients for solver;
 used when preconditionerChoice='file'.
 
 Default: 'unknownPrecondFile'
@@ -1451,7 +1451,7 @@ id="convect_visc"
 type="real"
 category="Vertical Mixing"
 group="vertical_mix_nml" >
-Momentum mixing coefficient to use with diffusion option. 
+Momentum mixing coefficient to use with diffusion option.
 
 Default: 10000.0
 </entry>
@@ -1460,7 +1460,7 @@ Default: 10000.0
 <!-- Group: geoheatflux_nml          - -->
 <!-- - - - - - - - - - - - - - - - - - -->
 
-<entry 
+<entry
 id="geoheatflux_choice"
 type="char*256"
 category="Forcing (Geothermal Heat Flux)"
@@ -1472,7 +1472,7 @@ Valid Values: 'const', 'spatial'
 Default: 'const'
 </entry>
 
-<entry 
+<entry
 id="geoheatflux_const"
 type="real"
 category="Forcing (Geothermal Heat Flux)"
@@ -1482,7 +1482,7 @@ Constant geothermal heat flux to apply to bottom layers. (W/m^2)
 Default: 0.0
 </entry>
 
-<entry 
+<entry
 id="geoheatflux_depth"
 type="real"
 category="Forcing (Geothermal Heat Flux)"
@@ -1555,7 +1555,7 @@ Note: You must specify both the variable name and namelist name if you change th
 <!-- Group: tidal_nml                - -->
 <!-- - - - - - - - - - - - - - - - - - -->
 
-<entry 
+<entry
 id="ltidal_schmittner_socn"
 type="logical"
 category="Vertical Mixing (Tidal)"
@@ -1565,7 +1565,7 @@ Flag to activate Schmittner's method southern ocean modification.
 Default: .true.
 </entry>
 
-<entry 
+<entry
 id="ltidal_all_TC_coefs_eq_1"
 type="logical"
 category="Vertical Mixing (Tidal)"
@@ -1576,7 +1576,7 @@ Do not activate this flag in a scientific experiment.
 Default: .false.
 </entry>
 
-<entry 
+<entry
 id="ltidal_all_TC_coefs_eq_p33"
 type="logical"
 category="Vertical Mixing (Tidal)"
@@ -1587,7 +1587,7 @@ Do not activate this flag in a scientific experiment.
 Default: .false.
 </entry>
 
-<entry 
+<entry
 id="ltidal_mixing"
 type="logical"
 category="Vertical Mixing (Tidal)"
@@ -1597,7 +1597,7 @@ Flag to activate tidal mixing.
 Default: .true.
 </entry>
 
-<entry 
+<entry
 id="ltidal_max"
 type="logical"
 category="Vertical Mixing (Tidal)"
@@ -1608,7 +1608,7 @@ Default: .true.
 </entry>
 
 
-<entry 
+<entry
 id="ltidal_stabc"
 type="logical"
 category="Vertical Mixing (Tidal)"
@@ -1618,7 +1618,7 @@ Flag to impose tidal_mix_max on all TIDAL_DIFF values.
 Default: .true.
 </entry>
 
-<entry 
+<entry
 id="ltidal_melet_plot"
 type="logical"
 category="Vertical Mixing (Tidal)"
@@ -1628,7 +1628,7 @@ Flag to activate collection of fields used to create Melet plot.
 Default: .false.
 </entry>
 
-<entry 
+<entry
 id="ltidal_lunar_cycle"
 type="logical"
 category="Vertical Mixing (Tidal)"
@@ -1638,17 +1638,17 @@ Flag to activate 18.6-year lunar cycle.
 Default: .false.
 </entry>
 
-<entry 
+<entry
 id="tidal_mixing_method_choice"
 type="char*256"
 category="Vertical Mixing (Tidal)"
-valid_values="jayne,polzin,schmittner" 
+valid_values="jayne,polzin,schmittner"
 group="tidal_nml" >
 Selector for tidal mixing scheme method.
 
 'jayne'
       Jayne, S. R., and L. C. St. Laurent, 2001: Parameterizing tidal
-        dissipation over rough topography. Geophys. Res. Lett., 
+        dissipation over rough topography. Geophys. Res. Lett.,
         v28, 811-814.
 
       Simmons, H. L., S. R. Jayne, L. C. St. Laurent, and
@@ -1674,19 +1674,19 @@ Selector for tidal mixing scheme method.
         vol 30, 298-309
 
       Melet, A. et al, 2013: Sensitivity of the ocean state to the
-        vertical distribution of the internal-tide-driven mixing. 
+        vertical distribution of the internal-tide-driven mixing.
         J. Phys Oceanography, vol 43, 602-615
 
 Default: 'jayne'
 </entry>
 
-<entry 
+<entry
 id="tidal_energy_choice"
 type="char*256"
 category="Vertical Mixing (Tidal)"
 valid_values="arbic,jayne,ER03,GN13,LGM0,LGMi5g21,LGMi6g21"
 group="tidal_nml" >
-Selector for tidal mixing energy file source. 
+Selector for tidal mixing energy file source.
 
 'jayne' Jayne 2009
 'arbic' not yet available
@@ -1699,7 +1699,7 @@ Selector for tidal mixing energy file source.
 Default: 'jayne'
 </entry>
 
-<entry 
+<entry
 id="tidal_eps_n2"
 type="real"
 category="Vertical Mixing (Tidal)"
@@ -1709,7 +1709,7 @@ Minimum value of N**2 used in tidal diffusion computations.
 Default: 1.0e-08
 </entry>
 
-<entry 
+<entry
 id="tidal_local_mixing_fraction"
 type="real"
 category="Vertical Mixing (Tidal)"
@@ -1719,7 +1719,7 @@ Fraction of energy available for mixing local to the generation region.
 Default: 0.33
 </entry>
 
-<entry 
+<entry
 id="tidal_mixing_efficiency"
 type="real"
 category="Vertical Mixing (Tidal)"
@@ -1729,7 +1729,7 @@ Tidal mixing efficiency. (Gamma)
 Default: 0.2
 </entry>
 
-<entry 
+<entry
 id="vertical_decay_scale"
 type="real"
 category="Vertical Mixing (Tidal)"
@@ -1739,11 +1739,11 @@ Vertical decay scale for turbulence (cm).
 Default: 500.0e02
 </entry>
 
-<entry 
+<entry
 id="tidal_vars_file_polz"
 type="char*512"
 category="Vertical Mixing (Tidal)"
-group="tidal_nml" 
+group="tidal_nml"
 input_pathname="abs" >
 Input file containing initialization variables (urms and topographic
 roughness) for use in the Polzin tidal mixing method.
@@ -1751,7 +1751,7 @@ roughness) for use in the Polzin tidal mixing method.
 Default: 'unknown_tidal_vars_file_polz'
 </entry>
 
-<entry 
+<entry
 id="tidal_diss_lim_TC"
 type="real"
 category="Vertical Mixing (Tidal)"
@@ -1763,7 +1763,7 @@ Active only when 3D tidal-constituent datasets are used.
 Default: 0.0e02
 </entry>
 
-<entry 
+<entry
 id="tidal_mix_max"
 type="real"
 category="Vertical Mixing (Tidal)"
@@ -1775,7 +1775,7 @@ Default: 100.0
 
 
 ################## TEST
-<entry 
+<entry
 id="ltidal_min_regions"
 type="logical"
 category="Vertical Mixing (Tidal)"
@@ -1785,7 +1785,7 @@ Apply minimum tidal mixing value in specified regions
 Default: .false.
 </entry>
 
-<entry 
+<entry
 id="num_tidal_min_regions"
 type="integer"
 category="Vertical Mixing (Tidal)"
@@ -1795,7 +1795,7 @@ Number of regions where minimum tidal-mixing values will be applied
 Default: 2
 </entry>
 
-<entry 
+<entry
 id="tidal_min_regions_klevels"
 type="integer(9)"
 category="Vertical Mixing (Tidal)"
@@ -1805,7 +1805,7 @@ Number of bottom k-levels where minimum tidal-mixing values will be applied
 Default: 6
 </entry>
 
-<entry 
+<entry
 id="tidal_min_regions_name"
 type="char*128(9)"
 category="Vertical Mixing (Tidal)"
@@ -1814,7 +1814,7 @@ Name of regions where minimum tidal-mixing values will be applied
 
 Default: 2
 </entry>
-<entry 
+<entry
 id="tidal_min_values"
 type="real(9)"
 category="Vertical Mixing (Tidal)"
@@ -1824,7 +1824,7 @@ Array of minimum tidal-mixing values
 Default: 1.0
 </entry>
 
-<entry 
+<entry
 id="tidal_TLATmin_regions"
 type="real(9)"
 category="Vertical Mixing (Tidal)"
@@ -1834,7 +1834,7 @@ Array of tidal-mixing lower TLAT values
 Default: 1.0
 </entry>
 
-<entry 
+<entry
 id="tidal_TLATmax_regions"
 type="real(9)"
 category="Vertical Mixing (Tidal)"
@@ -1844,7 +1844,7 @@ Array of tidal-mixing upper TLAT values
 Default: 1.0
 </entry>
 
-<entry 
+<entry
 id="tidal_TLONmin_regions"
 type="real(9)"
 category="Vertical Mixing (Tidal)"
@@ -1854,7 +1854,7 @@ Array of tidal-mixing lower TLON values
 Default: 1.0
 </entry>
 
-<entry 
+<entry
 id="tidal_TLONmax_regions"
 type="real(9)"
 category="Vertical Mixing (Tidal)"
@@ -1865,7 +1865,7 @@ Default: 1.0
 </entry>
 ################## TEST
 
-<entry 
+<entry
 id="tidal_energy_file"
 type="char*512"
 category="Vertical Mixing (Tidal)"
@@ -1876,19 +1876,19 @@ Input file containing tidal energy.
 Default: 'unknown_tidal_energy_file'
 </entry>
 
-<entry 
+<entry
 id="tidal_energy_file_fmt"
 type="char*256"
 category="Vertical Mixing (Tidal)"
 group="tidal_nml"
 valid_values="bin,nc" >
-File format of the tidal_energy_file file. 
+File format of the tidal_energy_file file.
 
 Valid Values: 'bin,nc'
 Default: 'nc'
 </entry>
 
-<entry 
+<entry
 id="tidal_energy_ts_files"
 type="char*1024(4)"
 category="Vertical Mixing (Tidal)"
@@ -1902,13 +1902,13 @@ Ignored if the lunar cycle is not active.
 Default: 'unknown_tidal_energy_ts_files'
 </entry>
 
-<entry 
+<entry
 id="tidal_energy_ts_file_fmt"
 type="char*256"
 category="Vertical Mixing (Tidal)"
 group="tidal_nml"
 valid_values="ascii" >
-File format of the tidal_energy_ts_file file. 
+File format of the tidal_energy_ts_file file.
 
 Ignored if the lunar cycle is not active.
 
@@ -1916,13 +1916,13 @@ Valid Values: 'ascii'
 Default: 'ascii'
 </entry>
 
-<entry 
+<entry
 id="tidal_energy_ts_calendar"
 type="char*256"
 category="Vertical Mixing (Tidal)"
 group="tidal_nml"
 valid_values="365" >
-tidal_energy_ts_file calendar type. 
+tidal_energy_ts_file calendar type.
 
 Ignored if the lunar cycle is not active.
 
@@ -1931,7 +1931,7 @@ Valid Values: '365'
 Default: '365'
 </entry>
 
-<entry 
+<entry
 id="tidal_energy_ts_model_yr_align"
 type="integer"
 category="Vertical Mixing (Tidal)"
@@ -1943,7 +1943,7 @@ Ignored if the lunar cycle is not active.
 Default: '1'
 </entry>
 
-<entry 
+<entry
 id="tidal_energy_ts_data_first_year"
 type="integer"
 category="Vertical Mixing (Tidal)"
@@ -1957,7 +1957,7 @@ Ignored if the lunar cycle is not active.
 Default: '1948'
 </entry>
 
-<entry 
+<entry
 id="tidal_energy_ts_data_first_month"
 type="integer"
 category="Vertical Mixing (Tidal)"
@@ -1975,7 +1975,7 @@ Ignored if the lunar cycle is not active.
 Default: '1'
 </entry>
 
-<entry 
+<entry
 id="tidal_energy_ts_data_first_day"
 type="integer"
 category="Vertical Mixing (Tidal)"
@@ -1993,7 +1993,7 @@ Ignored if the lunar cycle is not active.
 Default: '1'
 </entry>
 
-<entry 
+<entry
 id="tidal_energy_ts_data_final_year"
 type="integer"
 category="Vertical Mixing (Tidal)"
@@ -2007,7 +2007,7 @@ Ignored if the lunar cycle is not active.
 Default: '2009'
 </entry>
 
-<entry 
+<entry
 id="tidal_energy_ts_data_final_month"
 type="integer"
 category="Vertical Mixing (Tidal)"
@@ -2023,11 +2023,11 @@ Ignored if the lunar cycle is not active.
 Default: ''
 </entry>
 
-<entry 
+<entry
 id="tidal_energy_ts_data_final_day"
 type="integer"
 category="Vertical Mixing (Tidal)"
-group="tidal_nml" 
+group="tidal_nml"
 valid_values="1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31" >
 Final day used in the model from the lunar-cycle timeseries data record.
 
@@ -2038,7 +2038,7 @@ Ignored if the lunar cycle is not active.
 Default: '1'
 </entry>
 
-<entry 
+<entry
 id="tidal_vars_file_fmt_polz"
 type="char*256"
 category="Vertical Mixing (Tidal)"
@@ -2051,7 +2051,7 @@ Ignored if the 'polzin' tidal_mixing_method_choice option is not active.
 Default: 'nc'
 </entry>
 
-<entry 
+<entry
 id="tidal_vert_decay_option_schm"
 type="char*256"
 category="Vertical Mixing (Tidal)"
@@ -2250,15 +2250,14 @@ Flag for using CVMix for mixing instead of POP routines
 Default: .true.
 </entry>
 
-<!--QL, 150526, Langmuir mixing options-->
 <entry
 id="langmuir_opt"
 type="char*256"
 category="Vertical Mixing (KPP)"
 group="vmix_kpp_nml" >
-Langmuir mixing parameterization option.
+Langmuir turbulence parameterization option.
 
-Valid Values: 'null', 'vr12-ma', 'vr12-en'
+Valid Values: 'null', 'vr12-ma', 'lf17'
 Default: 'vr12-ma'
 </entry>
 
@@ -5831,7 +5830,7 @@ Default: 'const'
 id="abio_atm_d14c_opt"
 type="char*256"
 category="Passive Tracers (Abiotic DIC & DIC14)"
-group="abio_dic_dic14_nml" 
+group="abio_dic_dic14_nml"
 valid_values="file,const,lat_bands" >
 Source of atmos D14C.
 
@@ -5847,7 +5846,7 @@ group="abio_dic_dic14_nml" >
 Default:
 </entry>
 
-<entry 
+<entry
 id="abio_atm_d14c_lat_band_vals"
 type="real(3)"
 category="passive_tracers"
@@ -6148,7 +6147,7 @@ type="char*256"
 category="Forcing (Ecosystem)"
 group="ecosys_forcing_data_nml"
 input_pathname="abs" >
-Default: 
+Default:
 o2_consumption_scalef_0.30_POP_gx1v6_20180623.nc (gx1v6,gx1v7)
 </entry>
 
@@ -7331,7 +7330,7 @@ id="h_upper"
 type="real"
 category="Estuary Box Model"
 group="estuary_nml" >
-Thickness (m) of upper layer of exchange flow. 
+Thickness (m) of upper layer of exchange flow.
 
 Default: none
 </entry>

--- a/drivers/mct/POP_CplIndices.F90
+++ b/drivers/mct/POP_CplIndices.F90
@@ -1,7 +1,7 @@
 module POP_CplIndices
- 
-  use seq_flds_mod, only : seq_flds_x2o_fields, seq_flds_o2x_fields 
-  use seq_flds_mod, only : seq_flds_i2o_per_cat, ice_ncat 
+
+  use seq_flds_mod, only : seq_flds_x2o_fields, seq_flds_o2x_fields
+  use seq_flds_mod, only : seq_flds_i2o_per_cat, ice_ncat
   use mcog, only : mcog_ncols, lmcog_flds_sent
   use mct_mod
 
@@ -12,13 +12,12 @@ module POP_CplIndices
 
   ! ocn -> drv
 
-  integer :: index_o2x_So_t      
+  integer :: index_o2x_So_t
   integer :: index_o2x_So_u
   integer :: index_o2x_So_v
   integer :: index_o2x_So_s
   integer :: index_o2x_So_dhdx
   integer :: index_o2x_So_dhdy
-  ! QL, 150526, to wav, boundary layer depth
   integer :: index_o2x_So_bldepth
   integer :: index_o2x_Fioo_q
   integer :: index_o2x_Faoo_fco2_ocn
@@ -34,15 +33,15 @@ module POP_CplIndices
   integer :: index_x2o_Faxa_nhx        ! nitrogen deposition (nhx) flux from atm (kgNm2/sec)
   integer :: index_x2o_Faxa_noy        ! nitrogen deposition (noy) flux from atm (kgNm2/sec)
 
-  ! QL, 150526, from wav
   integer :: index_x2o_Sw_lamult       ! wave model langmuir multiplier
   integer :: index_x2o_Sw_ustokes      ! surface Stokes drift, x-component
   integer :: index_x2o_Sw_vstokes      ! surface Stokes drift, y-component
+  integer :: index_x2o_Sw_hstokes      ! surface layer Langmuir number for now
   integer :: index_x2o_Foxx_taux       ! zonal wind stress (taux)         (W/m2   )
   integer :: index_x2o_Foxx_tauy       ! meridonal wind stress (tauy)     (W/m2   )
   integer :: index_x2o_Foxx_swnet      ! net short-wave heat flux         (W/m2   )
   integer :: index_x2o_Foxx_sen        ! sensible heat flux               (W/m2   )
-  integer :: index_x2o_Foxx_lat        
+  integer :: index_x2o_Foxx_lat
   integer :: index_x2o_Foxx_lwup       ! longwave radiation (up)          (W/m2   )
   integer :: index_x2o_Faxa_lwdn       ! longwave radiation (down)        (W/m2   )
   integer :: index_x2o_Fioi_melth      ! heat flux from snow & ice melt   (W/m2   )
@@ -52,7 +51,7 @@ module POP_CplIndices
   integer :: index_x2o_Fioi_flxdst     ! flux: dust release from sea ice component
   integer :: index_x2o_Fioi_salt       ! salt                             (kg(salt)/m2/s)
   integer :: index_x2o_Foxx_evap       ! evaporation flux                 (kg/m2/s)
-  integer :: index_x2o_Faxa_prec         
+  integer :: index_x2o_Faxa_prec
   integer :: index_x2o_Faxa_snow       ! water flux due to snow           (kg/m2/s)
   integer :: index_x2o_Faxa_rain       ! water flux due to rain           (kg/m2/s)
   integer :: index_x2o_Faxa_bcphidry   ! flux: Black   Carbon hydrophilic dry deposition
@@ -101,7 +100,6 @@ contains
     index_o2x_So_s          = mct_avect_indexra(o2x,'So_s')
     index_o2x_So_dhdx       = mct_avect_indexra(o2x,'So_dhdx')
     index_o2x_So_dhdy       = mct_avect_indexra(o2x,'So_dhdy')
-    ! QL, 150526, to wav, boundary layer depth
     index_o2x_So_bldepth    = mct_avect_indexra(o2x,'So_bldepth')
     index_o2x_Fioo_q        = mct_avect_indexra(o2x,'Fioo_q')
     index_o2x_Faoo_fco2_ocn = mct_avect_indexra(o2x,'Faoo_fco2_ocn',perrWith='quiet')
@@ -109,10 +107,10 @@ contains
     index_x2o_Si_ifrac      = mct_avect_indexra(x2o,'Si_ifrac')
     index_x2o_Sa_pslv       = mct_avect_indexra(x2o,'Sa_pslv')
     index_x2o_So_duu10n     = mct_avect_indexra(x2o,'So_duu10n')
-    ! QL, 150526, from wav
     index_x2o_Sw_lamult     = mct_avect_indexra(x2o,'Sw_lamult')
     index_x2o_Sw_ustokes    = mct_avect_indexra(x2o,'Sw_ustokes')
     index_x2o_Sw_vstokes    = mct_avect_indexra(x2o,'Sw_vstokes')
+    index_x2o_Sw_hstokes    = mct_avect_indexra(x2o,'Sw_hstokes')
 
     index_x2o_Foxx_tauy     = mct_avect_indexra(x2o,'Foxx_tauy')
     index_x2o_Foxx_taux     = mct_avect_indexra(x2o,'Foxx_taux')
@@ -121,15 +119,15 @@ contains
     index_x2o_Foxx_sen      = mct_avect_indexra(x2o,'Foxx_sen')
     index_x2o_Foxx_lwup     = mct_avect_indexra(x2o,'Foxx_lwup')
     index_x2o_Faxa_lwdn     = mct_avect_indexra(x2o,'Faxa_lwdn')
-    index_x2o_Fioi_melth    = mct_avect_indexra(x2o,'Fioi_melth')   
+    index_x2o_Fioi_melth    = mct_avect_indexra(x2o,'Fioi_melth')
     index_x2o_Fioi_meltw    = mct_avect_indexra(x2o,'Fioi_meltw')
-    index_x2o_Fioi_salt     = mct_avect_indexra(x2o,'Fioi_salt')   
+    index_x2o_Fioi_salt     = mct_avect_indexra(x2o,'Fioi_salt')
     index_x2o_Fioi_bcpho    = mct_avect_indexra(x2o,'Fioi_bcpho')
     index_x2o_Fioi_bcphi    = mct_avect_indexra(x2o,'Fioi_bcphi')
     index_x2o_Fioi_flxdst   = mct_avect_indexra(x2o,'Fioi_flxdst')
-    index_x2o_Faxa_prec     = mct_avect_indexra(x2o,'Faxa_prec')   
-    index_x2o_Faxa_snow     = mct_avect_indexra(x2o,'Faxa_snow')   
-    index_x2o_Faxa_rain     = mct_avect_indexra(x2o,'Faxa_rain')   
+    index_x2o_Faxa_prec     = mct_avect_indexra(x2o,'Faxa_prec')
+    index_x2o_Faxa_snow     = mct_avect_indexra(x2o,'Faxa_snow')
+    index_x2o_Faxa_rain     = mct_avect_indexra(x2o,'Faxa_rain')
     index_x2o_Foxx_evap     = mct_avect_indexra(x2o,'Foxx_evap')
     index_x2o_Foxx_rofl     = mct_avect_indexra(x2o,'Foxx_rofl')
     index_x2o_Foxx_rofi     = mct_avect_indexra(x2o,'Foxx_rofi')

--- a/drivers/mct/ocn_import_export.F90
+++ b/drivers/mct/ocn_import_export.F90
@@ -12,7 +12,7 @@ module ocn_import_export
 
    use seq_flds_mod
    use seq_timemgr_mod
-   use shr_file_mod 
+   use shr_file_mod
    use shr_cal_mod,       only : shr_cal_date2ymd
    use shr_sys_mod
 
@@ -31,7 +31,7 @@ module ocn_import_export
    use forcing_fields,    only: ATM_CO2_PROG_nf_ind, ATM_CO2_DIAG_nf_ind
    use forcing_fields,    only: ATM_NHx_nf_ind, ATM_NOy_nf_ind
    use forcing_fields,    only: IFRAC, U10_SQR, ATM_PRESS
-   use forcing_fields,    only: LAMULT, USTOKES, VSTOKES
+   use forcing_fields,    only: LAMULT, USTOKES, VSTOKES, LASL
    use forcing_fields,    only: ATM_FINE_DUST_FLUX, ATM_COARSE_DUST_FLUX, SEAICE_DUST_FLUX
    use forcing_fields,    only: ATM_BLACK_CARBON_FLUX, SEAICE_BLACK_CARBON_FLUX
    use mcog,              only: lmcog, mcog_ncols, import_mcog
@@ -49,7 +49,7 @@ module ocn_import_export
    use prognostic
    use time_management
    use registry
-   ! QL, 150526, ocn<->wav
+   ! ocn<->wav
    use vmix_kpp,          only: KPP_HBLT      ! ocn -> wav, bounadry layer depth
 
    implicit none
@@ -57,9 +57,9 @@ module ocn_import_export
    save
 
    ! accumulated sum of send buffer quantities for averaging before being sent
-   real (r8), dimension(:,:,:,:), allocatable ::  SBUFF_SUM 
+   real (r8), dimension(:,:,:,:), allocatable ::  SBUFF_SUM
 
-   real (r8) :: tlast_coupled 
+   real (r8) :: tlast_coupled
 
 contains
 
@@ -75,7 +75,7 @@ contains
 !  This routine receives message from cpl7 driver
 !
 !    The following fields are always received from the coupler:
-! 
+!
 !    o  taux   -- zonal wind stress (taux)                 (W/m2   )
 !    o  tauy   -- meridonal wind stress (tauy)             (W/m2   )
 !    o  snow   -- water flux due to snow                   (kg/m2/s)
@@ -91,15 +91,15 @@ contains
 !    o  ifrac  -- ice fraction
 !    o  rofl   -- river runoff flux                        (kg/m2/s)
 !    o  rofi   -- ice runoff flux                          (kg/m2/s)
-! 
+!
 !    The following fields are sometimes received from the coupler,
 !      depending on model options:
-! 
+!
 !    o  pslv   -- sea-level pressure                       (Pa)
 !    o  duu10n -- 10m wind speed squared                   (m^2/s^2)
 !    o  co2prog-- bottom atm level prognostic co2
 !    o  co2diag-- bottom atm level diagnostic co2
-! 
+!
 !-----------------------------------------------------------------------
 !
 ! !REVISION HISTORY:
@@ -122,7 +122,7 @@ contains
    character (char_len) ::   &
       label,                 &
       message
- 
+
    integer (int_kind) ::  &
       i,j,k,n,ncol,iblock
 
@@ -145,7 +145,7 @@ contains
 
 !-----------------------------------------------------------------------
 !
-!  zero out padded cells 
+!  zero out padded cells
 !
 !-----------------------------------------------------------------------
 
@@ -184,7 +184,7 @@ contains
 !  rotate true zonal/meridional wind stress into local coordinates,
 !  convert to dyne/cm**2, and shift SMFT to U grid
 !
-!  halo updates are performed in subroutine rotate_wind_stress, 
+!  halo updates are performed in subroutine rotate_wind_stress,
 !  following the rotation
 !
 !-----------------------------------------------------------------------
@@ -237,9 +237,9 @@ contains
          !***  converting from m**2/s**2 to cm**2/s**2
          WORKB(i,j       ) = x2o(index_x2o_So_duu10n,n)
          U10_SQR(i,j,iblock) = cmperm * cmperm * WORKB(i,j) * RCALCT(i,j,iblock)
-         
-         ! QL, 150526, langmuir mixing variables
-         ! QL, 150908, only apply enhancement factor to ice-free region
+
+         ! langmuir mixing variables
+         ! apply enhancement factor to ice-free region
          if (IFRAC(i,j,iblock) <= 0.05_r8) then
             ! import enhancement factor (unitless)
             WORKB(i,j       ) = x2o(index_x2o_Sw_lamult,n)
@@ -247,16 +247,19 @@ contains
          else
             LAMULT(i,j,iblock) = c1
          endif
-         ! QL, 150706, DEBUG
-         !print*, "LAMULT = ", LAMULT(i,j,iblock)  
-         !print*, "RCALCT = ", RCALCT(i,j,iblock)  
-         !print*, "WORKB = ", WORKB(i,j)  
-         !! DEBUG
          ! import surface Stokes drift (m/s)
          WORKB(i,j       ) = x2o(index_x2o_Sw_ustokes,n)
          USTOKES(i,j,iblock) = WORKB(i,j)*RCALCT(i,j,iblock)
          WORKB(i,j       ) = x2o(index_x2o_Sw_vstokes,n)
          VSTOKES(i,j,iblock) = WORKB(i,j)*RCALCT(i,j,iblock)
+         ! apply surface layer Langmuir number to ice-free region
+         if (IFRAC(i,j,iblock) <= 0.05_r8) then
+            ! import surface layer Langmuir number (unitless)
+            WORKB(i,j       ) = x2o(index_x2o_Sw_hstokes,n)
+            LASL(i,j,iblock) = WORKB(i,j)*RCALCT(i,j,iblock)
+         else
+            LASL(i,j,iblock) = c10000 ! a big number
+         endif
 
          ! convert dust flux from MKS (kg/m^2/s) to CGS (g/cm^2/s)
          ATM_FINE_DUST_FLUX(i,j,iblock) = 0.1_r8 * RCALCT(i,j,iblock) * ( &
@@ -415,7 +418,7 @@ contains
 
       call named_field_set(ATM_CO2_DIAG_nf_ind, WORK1)
    endif
- 
+
    if (index_x2o_Faxa_nhx > 0) then
       n = 0
       do iblock = 1, nblocks_clinic
@@ -427,7 +430,7 @@ contains
          do j=this_block%jb,this_block%je
          do i=this_block%ib,this_block%ie
             n = n + 1
-            WORK1(i,j,iblock) = x2o(index_x2o_Faxa_nhx,n) * (1.0e-1_r8 * (c1/14.0_r8) * 1.0e9_r8) 
+            WORK1(i,j,iblock) = x2o(index_x2o_Faxa_nhx,n) * (1.0e-1_r8 * (c1/14.0_r8) * 1.0e9_r8)
          enddo
          enddo
       enddo
@@ -489,7 +492,7 @@ contains
          ' Global averages of fluxes received from cpl at ',  &
            cyear,'/',cmonth ,'/',cday,  chour,':',cminute,':',csecond
      call document ('pop_recv_from_coupler', trim(message))
- 
+
      m2percm2  = mpercm*mpercm
      nrecv = size(x2o, dim=1)
      do k = 1,nrecv
@@ -529,7 +532,7 @@ contains
 ! !IROUTINE: ocn_export_mct
 ! !INTERFACE:
 
- subroutine ocn_export(o2x, ldiag_cpl, errorCode)   
+ subroutine ocn_export(o2x, ldiag_cpl, errorCode)
 
 ! !DESCRIPTION:
 !  This routine calls the routines necessary to send pop fields to
@@ -553,9 +556,9 @@ contains
 !-----------------------------------------------------------------------
 
    integer (int_kind) :: n, iblock
-           
+
    character (char_len)    :: label
- 
+
    integer (int_kind) ::  &
         i,j,k
 
@@ -676,7 +679,7 @@ contains
       this_block = get_block(blocks_clinic(iblock),iblock)
       call ugrid_to_tgrid(WORK3,SBUFF_SUM(:,:,iblock,index_o2x_So_dhdx),iblock)
       call ugrid_to_tgrid(WORK4,SBUFF_SUM(:,:,iblock,index_o2x_So_dhdy),iblock)
- 
+
       WORK1 = (WORK3*cos(ANGLET(:,:,iblock)) + WORK4*sin(-ANGLET(:,:,iblock)))  &
               /grav/tlast_coupled
       WORK2 = (WORK4*cos(ANGLET(:,:,iblock)) - WORK3*sin(-ANGLET(:,:,iblock)))  &
@@ -765,7 +768,7 @@ contains
                        POP_gridHorzLocCenter,          &
                        POP_fieldKindScalar, errorCode, &
                        fillValue = 0.0_POP_r8)
-       
+
          if (errorCode /= POP_Success) then
             call POP_ErrorSet(errorCode, &
                'ocn_export_mct: error updating halo for state')
@@ -783,7 +786,7 @@ contains
    endif
 
 1100 format ('comm_diag ', a3, 1x, a4, 1x, a8, 1x, es26.19:, 1x, a6)
-    
+
     tlast_coupled = c0
 
 !-----------------------------------------------------------------------
@@ -805,7 +808,7 @@ contains
 !
 ! !REVISION HISTORY:
 !  same as module
-! 
+!
 !EOP
 !BOC
 
@@ -933,7 +936,7 @@ contains
 !EOC
 
  end subroutine POP_sum_buffer
- 
+
 !***********************************************************************
 
 end module ocn_import_export

--- a/drivers/mct/ocn_import_export.F90
+++ b/drivers/mct/ocn_import_export.F90
@@ -258,7 +258,7 @@ contains
             WORKB(i,j       ) = x2o(index_x2o_Sw_hstokes,n)
             LASL(i,j,iblock) = WORKB(i,j)*RCALCT(i,j,iblock)
          else
-            LASL(i,j,iblock) = bignum
+            LASL(i,j,iblock) = -c1
          endif
 
          ! convert dust flux from MKS (kg/m^2/s) to CGS (g/cm^2/s)

--- a/drivers/mct/ocn_import_export.F90
+++ b/drivers/mct/ocn_import_export.F90
@@ -258,7 +258,7 @@ contains
             WORKB(i,j       ) = x2o(index_x2o_Sw_hstokes,n)
             LASL(i,j,iblock) = WORKB(i,j)*RCALCT(i,j,iblock)
          else
-            LASL(i,j,iblock) = c10000 ! a big number
+            LASL(i,j,iblock) = bignum
          endif
 
          ! convert dust flux from MKS (kg/m^2/s) to CGS (g/cm^2/s)

--- a/drivers/nuopc/ocn_import_export.F90
+++ b/drivers/nuopc/ocn_import_export.F90
@@ -587,7 +587,7 @@ contains
     where (IFRAC <= 0.05_r8)
        LASL(:,:,:) = work1 * RCALCT(:,:,:) ! surface layer Lanmguir number (unitless)
     elsewhere
-       LASL(:,:,:) = c10000 ! a big number
+       LASL(:,:,:) = bignum
     end where
 
     !-----------------------------------------------------------------------

--- a/drivers/nuopc/ocn_import_export.F90
+++ b/drivers/nuopc/ocn_import_export.F90
@@ -23,7 +23,7 @@ module ocn_import_export
   use forcing_fields,        only: ATM_CO2_PROG_nf_ind, ATM_CO2_DIAG_nf_ind
   use forcing_fields,        only: ATM_NHx_nf_ind, ATM_NOy_nf_ind
   use forcing_fields,        only: IFRAC, U10_SQR, ATM_PRESS
-  use forcing_fields,        only: LAMULT, USTOKES, VSTOKES
+  use forcing_fields,        only: LAMULT, USTOKES, VSTOKES, LASL
   use forcing_fields,        only: ATM_FINE_DUST_FLUX, ATM_COARSE_DUST_FLUX, SEAICE_DUST_FLUX
   use forcing_fields,        only: ATM_BLACK_CARBON_FLUX, SEAICE_BLACK_CARBON_FLUX
   use mcog,                  only: lmcog, mcog_ncols, lmcog_flds_sent, import_mcog
@@ -184,6 +184,7 @@ contains
     call fldlist_add(fldsToOcn_num, fldsToOcn, 'Sw_lamult')
     call fldlist_add(fldsToOcn_num, fldsToOcn, 'Sw_ustokes')
     call fldlist_add(fldsToOcn_num, fldsToOcn, 'Sw_vstokes')
+    call fldlist_add(fldsToOcn_num, fldsToOcn, 'Sw_hstokes')
 
     ! from atmosphere
     call fldlist_add(fldsToOcn_num, fldsToOcn, 'Sa_pslv')
@@ -580,6 +581,14 @@ contains
     call state_getimport(importState, 'Sw_vstokes', work1, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     VSTOKES(:,:,:) = work1(:,:,:) * RCALCT(:,:,:) ! Stokes drift (m/s)
+
+    call state_getimport(importState, 'Sw_hstokes', work1, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    where (IFRAC <= 0.05_r8)
+       LASL(:,:,:) = work1 * RCALCT(:,:,:) ! surface layer Lanmguir number (unitless)
+    elsewhere
+       LASL(:,:,:) = c10000 ! a big number
+    end where
 
     !-----------------------------------------------------------------------
     ! from river

--- a/drivers/nuopc/ocn_import_export.F90
+++ b/drivers/nuopc/ocn_import_export.F90
@@ -587,7 +587,7 @@ contains
     where (IFRAC <= 0.05_r8)
        LASL(:,:,:) = work1 * RCALCT(:,:,:) ! surface layer Lanmguir number (unitless)
     elsewhere
-       LASL(:,:,:) = bignum
+       LASL(:,:,:) = -c1
     end where
 
     !-----------------------------------------------------------------------

--- a/source/forcing_coupled.F90
+++ b/source/forcing_coupled.F90
@@ -15,7 +15,7 @@
 !  SVN:$Id$
 !
 ! !USES:
- 
+
    use POP_KindsMod
    use POP_ErrorMod
    use POP_CommMod
@@ -56,7 +56,7 @@
    use estuary_vsf_mod, only: set_estuary_vsf_forcing, set_estuary_exch_circ
    use mcog, only: tavg_mcog
    use mcog, only: FRAC_BIN, QSW_RAW_BIN
-      
+
    implicit none
    save
 
@@ -132,7 +132,7 @@
       QSW_COSZ_WGHT,      & ! weights
       QSW_COSZ_WGHT_NORM    ! normalization for QSW_COSZ_WGHT
 
- 
+
    integer (int_kind), private ::   &
       cpl_ts                ! flag id for coupled_ts flag
 
@@ -145,13 +145,13 @@
 !***********************************************************************
 
 !BOP
-! !IROUTINE: pop_init_coupled 
+! !IROUTINE: pop_init_coupled
 ! !INTERFACE:
 
  subroutine pop_init_coupled
 
 ! !DESCRIPTION:
-!  This routine sets up everything necessary for coupling with CCSM4. 
+!  This routine sets up everything necessary for coupling with CCSM4.
 !
 ! !REVISION HISTORY:
 !  same as module
@@ -204,12 +204,12 @@
 !  coupling frequency
 !
 !-----------------------------------------------------------------------
-      
+
    coupled_freq_opt  = 'never'
    coupled_freq_iopt = freq_opt_never
    coupled_freq      = 100000
    qsw_distrb_opt    = 'const'
-      
+
    if (my_task == master_task) then
       open (nml_in, file=nml_filename, status='old',iostat=nml_error)
       if (nml_error /= 0) then
@@ -301,7 +301,7 @@
         end select
 
       endif
-            
+
       call broadcast_scalar(coupled_freq_iopt, master_task)
       call broadcast_scalar(coupled_freq     , master_task)
       call broadcast_scalar(qsw_distrb_iopt  , master_task)
@@ -356,18 +356,18 @@
 !-----------------------------------------------------------------------
 
       allocate ( qsw_12hr_factor(nsteps_per_interval))
-      
+
       qsw_12hr_factor = c1
       if ( qsw_distrb_iopt == qsw_distrb_iopt_12hr ) then
 
 !       mimic a day
 
-        time_for_forcing = c0 
+        time_for_forcing = c0
         count_forcing    =  1
         sum_forcing      = c0
 
         do n=1,nsteps_per_interval
-          frac_day_forcing = time_for_forcing / seconds_in_day 
+          frac_day_forcing = time_for_forcing / seconds_in_day
           cycle_function = cos( pi * ( c2 * frac_day_forcing - c1 ) )
           qsw_12hr_factor(n) = c2 * (      cycle_function      &
                                      + abs(cycle_function) )   &
@@ -511,7 +511,7 @@
 !  initialize timer for computing cosz
 !
 !-----------------------------------------------------------------------
-      
+
    if ( qsw_distrb_iopt == qsw_distrb_iopt_cosz ) then
       call get_timer (timer_compute_cosz, 'COMPUTE_COSZ', nblocks_clinic, &
                                           distrb_clinic%nprocs)
@@ -655,7 +655,7 @@
      write(stdout,*) message
      number_of_fatal_errors = number_of_fatal_errors + 1
    endif
-   
+
    if (number_of_fatal_errors /= 0)  &
       call exit_POP(sigAbort,'subroutine pop_init_partially_coupled')
 
@@ -679,9 +679,9 @@
 
 ! !DESCRIPTION:
 !  This routine is called immediately following the receipt of fluxes
-!  from the coupler. It combines fluxes received from the coupler into 
-!  the STF array and converts from W/m**2 into model units. It also 
-!  balances salt/freshwater in marginal seas and sets SHF_QSW_RAW 
+!  from the coupler. It combines fluxes received from the coupler into
+!  the STF array and converts from W/m**2 into model units. It also
+!  balances salt/freshwater in marginal seas and sets SHF_QSW_RAW
 !  and SHF_COMP. Compute QSW_COSZ_WGHT_NORM if needed.
 !
 ! !REVISION HISTORY:
@@ -690,7 +690,7 @@
 
 !EOP
 !BOC
-     
+
 !-----------------------------------------------------------------------
 !
 !  local variables
@@ -704,7 +704,7 @@
 
    real (r8), dimension(nx_block,ny_block,max_blocks_clinic) ::   &
       WORK1, WORK2        ! local work space
- 
+
 !-----------------------------------------------------------------------
 !
 !  combine heat flux components into STF array and convert from W/m**2
@@ -724,10 +724,10 @@
                            + SENH_F(:,:,iblock) + LWUP_F(:,:,iblock)        &
                            + LWDN_F(:,:,iblock) + MELTH_F(:,:,iblock)       &
                            -(SNOW_F(:,:,iblock)+IOFF_F(:,:,iblock)) * latent_heat_fusion_mks)*  &
-                             RCALCT(:,:,iblock)*hflux_factor 
+                             RCALCT(:,:,iblock)*hflux_factor
    enddo
    !$OMP END PARALLEL DO
-                                        
+
 !-----------------------------------------------------------------------
 !
 !  combine freshwater flux components
@@ -817,7 +817,7 @@
                     + SALT_F(:,:,iblock)*sflux_factor)
       enddo
       !$OMP END PARALLEL DO
- 
+
       if ( lestuary_on ) then
 !  Treat river runoff as the interior source
         if (lvsf_river) call set_estuary_vsf_forcing
@@ -841,14 +841,14 @@
 !  balance salt/freshwater in marginal seas
 !
 !-----------------------------------------------------------------------
- 
+
       if  (lms_balance .and. sfwf_formulation /= 'partially-coupled' ) then
        call ms_balancing (STF(:,:,2,:),EVAP_F, PREC_F, MELT_F,ROFF_F,IOFF_F,   &
                           SALT_F, QFLUX, 'salt')
       endif
- 
+
    endif
- 
+
 
    !$OMP PARALLEL DO PRIVATE(iblock,n)
    do iblock = 1, nblocks_clinic
@@ -856,14 +856,14 @@
       SHF_QSW_RAW(:,:,iblock) = SHF_QSW(:,:,iblock)
 
       if ( shf_formulation == 'partially-coupled' ) then
-        SHF_COMP(:,:,iblock,shf_comp_cpl) = STF(:,:,1,iblock) 
+        SHF_COMP(:,:,iblock,shf_comp_cpl) = STF(:,:,1,iblock)
         if ( .not. lms_balance ) then
           SHF_COMP(:,:,iblock,shf_comp_cpl) =   &
                   SHF_COMP(:,:,iblock,shf_comp_cpl) * MASK_SR(:,:,iblock)
           SHF_QSW(:,:,iblock) = SHF_QSW(:,:,iblock) * MASK_SR(:,:,iblock)
         endif
       endif
- 
+
       SHF_COMP(:,:,iblock,shf_comp_qsw) = SHF_QSW(:,:,iblock)
 
       if ( sfwf_formulation == 'partially-coupled' ) then
@@ -890,7 +890,7 @@
         endif
 
       endif
- 
+
       if ( luse_cpl_ifrac ) then
         OCN_WGT(:,:,iblock) = (c1-IFRAC(:,:,iblock)) * RCALCT(:,:,iblock)
       endif
@@ -937,7 +937,7 @@
        enddo
        !$OMP END PARALLEL DO
     endif
- 
+
 #endif
 !-----------------------------------------------------------------------
 !EOC
@@ -962,7 +962,7 @@
 !  same as module
 
 ! !INPUT/OUTPUT PARAMETERS:
- 
+
    real (r8), dimension(nx_block,ny_block,nt,max_blocks_clinic), &
       intent(inout) :: &
       STF,             &! surface tracer fluxes at current timestep
@@ -1040,17 +1040,17 @@
          enddo
          !$OMP END PARALLEL DO
 
-       else     
+       else
 
          !$OMP PARALLEL DO PRIVATE(iblock)
          do iblock=1,nblocks_clinic
            STF(:,:,2,iblock) =  SFWF_COMP(:,:,iblock,sfwf_comp_wrest)  &
                               + SFWF_COMP(:,:,iblock,sfwf_comp_srest)  &
                               + SFWF_COMP(:,:,iblock,sfwf_comp_cpl)    &
-                              + SFWF_COMP(:,:,iblock,sfwf_comp_flxio) 
+                              + SFWF_COMP(:,:,iblock,sfwf_comp_flxio)
          enddo
          !$OMP END PARALLEL DO
- 
+
        endif
      endif
    endif
@@ -1062,8 +1062,8 @@
 !EOC
 
  end subroutine set_combined_forcing
- 
- 
+
+
 !***********************************************************************
 !BOP
 ! !IROUTINE: tavg_coupled_forcing
@@ -1149,7 +1149,7 @@
 
 ! !OUTPUT PARAMETERS:
 
-   integer (POP_i4), intent(out) :: errorCode  
+   integer (POP_i4), intent(out) :: errorCode
 
 !EOP
 !BOC
@@ -1327,7 +1327,6 @@
       return
    endif
 
-! QL, 150526, LAMULT, USTOKES and VSTOKES
    call POP_HaloUpdate(LAMULT,POP_haloClinic,         &
                        POP_gridHorzLocCenter,          &
                        POP_fieldKindScalar, errorCode, &
@@ -1358,6 +1357,17 @@
    if (errorCode /= POP_Success) then
       call POP_ErrorSet(errorCode, &
          'update_ghost_cells_coupler: error updating VSTOKES')
+      return
+   endif
+
+   call POP_HaloUpdate(LASL,POP_haloClinic,            &
+                       POP_gridHorzLocCenter,          &
+                       POP_fieldKindScalar, errorCode, &
+                       fillValue = 0.0_POP_r8)
+
+   if (errorCode /= POP_Success) then
+      call POP_ErrorSet(errorCode, &
+         'update_ghost_cells_coupler: error updating LASL')
       return
    endif
 
@@ -1444,7 +1454,7 @@
 
  end subroutine update_ghost_cells_coupler_fluxes
 
- 
+
 !***********************************************************************
 !BOP
 ! !IROUTINE: rotate_wind_stress
@@ -1473,8 +1483,8 @@
 !  local variables
 !
 !-----------------------------------------------------------------------
-   integer (kind=int_kind) :: iblock  
-   integer (POP_i4)        :: errorCode  
+   integer (kind=int_kind) :: iblock
+   integer (POP_i4)        :: errorCode
 
 !-----------------------------------------------------------------------
 !

--- a/source/forcing_fields.F90
+++ b/source/forcing_fields.F90
@@ -18,7 +18,7 @@ module forcing_fields
    use blocks,      only: nx_block, ny_block
    use constants,   only: c0
    use domain_size, only: max_blocks_clinic,nt
-      
+
    implicit none
    save
 
@@ -77,7 +77,8 @@ module forcing_fields
       ATM_PRESS,         &! atmospheric pressure forcing
       FW,FW_OLD,         &! freshwater flux at T points (cm/s)
                           ! FW_OLD is at time n-1
-      LAMULT,            &! Langmuir multiplier, QL, 150526
+      LAMULT,            &! Langmuir multiplier
+      LASL,              &! surface layer averaged Langmuir number
       USTOKES,           &! surface Stokes drift x component
       VSTOKES             ! surface Stokes drift y component
 

--- a/source/vmix_kpp.F90
+++ b/source/vmix_kpp.F90
@@ -45,7 +45,7 @@
    use cvmix_kpp
    use cvmix_math
    use shr_sys_mod
-   use forcing_fields, only: LAMULT
+   use forcing_fields, only: LAMULT, LASL
 
    implicit none
    private
@@ -2512,7 +2512,10 @@
                           delta_buoy_cntr = (/DBSFC(i,j,kl)/)*1e-2_r8,        &
                           delta_Vsqr_cntr = (/VSHEAR(i,j)/)*1e-4_r8,          &
                           N_iface = (/B_FRQNCY(i,j), B_FRQNCY(i,j)/),         &
-                          EFactor = LAMULT(i,j,bid))
+                          EFactor = LAMULT(i,j,bid),                          &
+                          LaSL = LASL(i,j,bid),                               &
+                          bfsfc = BFSFC(i,j)*1e-4_r8,                         &
+                          ustar = USTAR(i,j)*1e-2_r8)
             else
 
 !-----------------------------------------------------------------------

--- a/source/vmix_kpp.F90
+++ b/source/vmix_kpp.F90
@@ -45,7 +45,7 @@
    use cvmix_kpp
    use cvmix_math
    use shr_sys_mod
-   use forcing_fields, only: LAMULT, LASL, IFRAC
+   use forcing_fields, only: LAMULT, LASL
 
    implicit none
    private
@@ -411,8 +411,8 @@
          langmuir_mixing_opt      = 'LWF16'
          langmuir_entrainment_opt = 'LF17'
       case default
-         call exit_POP(sigAbort, &
-             'ERROR: Unknown option for Langmuir turbulence parameterization')
+         write(string, "(3A)") "Error: '", trim(langmuir_opt), "' is not a valid option for Langmuir turbulence parameterization"
+         call exit_POP(sigAbort, string)
       end select
 
    endif
@@ -2506,9 +2506,9 @@
           do i = 1,nx_block
             ic = (j-1)*nx_block + i
             if (kl.le.CVmix_vars(ic)%nlev) then
-              if (IFRAC(i,j,bid) <= 0.05_r8 .and. LASL(i,j,bid) > c0) then
-                ! only use Langmuir enhanced entrainment in ice-free regions
-                ! where ice fraction is less than 5% and LaSL has a valid value
+              if (LASL(i,j,bid) > c0) then
+                ! only use Langmuir enhanced entrainment where LaSL has
+                ! a valid (positive) value.
                 RI_BULK(i,j,kdn:kdn) = cvmix_kpp_compute_bulk_Richardson(     &
                             zt_cntr = (/zgrid(kl)/)*1e-2_r8,                  &
                             ws_cntr = (/WS(i,j)/)*1e-2_r8,                    &
@@ -2523,7 +2523,6 @@
                 ! otherwise use the original formula of the unresolved shear
                 ! by setting bfsfc to zero, as the new formula is only used
                 ! when bfsfc < 0
-                ! EFactor is already set to 1 where IFRAC <= 0.05
                 RI_BULK(i,j,kdn:kdn) = cvmix_kpp_compute_bulk_Richardson(     &
                             zt_cntr = (/zgrid(kl)/)*1e-2_r8,                  &
                             ws_cntr = (/WS(i,j)/)*1e-2_r8,                    &

--- a/source/vmix_kpp.F90
+++ b/source/vmix_kpp.F90
@@ -2506,9 +2506,9 @@
           do i = 1,nx_block
             ic = (j-1)*nx_block + i
             if (kl.le.CVmix_vars(ic)%nlev) then
-              if (IFRAC(i,j,bid) <= 0.05_r8) then
+              if (IFRAC(i,j,bid) <= 0.05_r8 .and. LASL(i,j,bid) > c0) then
                 ! only use Langmuir enhanced entrainment in ice-free regions
-                ! where ice fraction is less than 5%
+                ! where ice fraction is less than 5% and LaSL has a valid value
                 RI_BULK(i,j,kdn:kdn) = cvmix_kpp_compute_bulk_Richardson(     &
                             zt_cntr = (/zgrid(kl)/)*1e-2_r8,                  &
                             ws_cntr = (/WS(i,j)/)*1e-2_r8,                    &

--- a/source/vmix_kpp.F90
+++ b/source/vmix_kpp.F90
@@ -399,7 +399,7 @@
 
       select case (langmuir_opt)
       case ('null')
-         write(stdout,'(a38)') '   no Lanmguir mixing parameterization'
+         write(stdout,'(a38)') '   no Lanmguir turbulence parameterization'
          langmuir_mixing_opt      = 'NONE'
          langmuir_entrainment_opt = 'NONE'
       case ('vr12-ma')
@@ -411,8 +411,8 @@
          langmuir_mixing_opt      = 'LWF16'
          langmuir_entrainment_opt = 'LF17'
       case default
-         langmuir_mixing_opt      = 'NONE'
-         langmuir_entrainment_opt = 'NONE'
+         call exit_POP(sigAbort, &
+             'ERROR: Unknown option for Langmuir turbulence parameterization')
       end select
 
    endif

--- a/source/vmix_kpp.F90
+++ b/source/vmix_kpp.F90
@@ -8,7 +8,7 @@
 ! !DESCRIPTION:
 !  This module contains routines for initializing and computing
 !  vertical mixing coefficients for the KPP parameterization
-!  (see Large, McWilliams and Doney, Reviews of Geophysics, 32, 363 
+!  (see Large, McWilliams and Doney, Reviews of Geophysics, 32, 363
 !  November 1994).
 !
 ! !REVISION HISTORY:
@@ -45,8 +45,7 @@
    use cvmix_kpp
    use cvmix_math
    use shr_sys_mod
-   ! QL, 150526, forcing from wav
-   use forcing_fields, only: LAMULT, USTOKES, VSTOKES
+   use forcing_fields, only: LAMULT
 
    implicit none
    private
@@ -63,7 +62,7 @@
 
 ! !PUBLIC DATA MEMBERS:
 
-   real (r8), dimension(:,:,:), allocatable, public :: & 
+   real (r8), dimension(:,:,:), allocatable, public :: &
       HMXL,               &! mixed layer depth
       HMXL_DR,            &! mixed layer depth with density criterion, QL, 150526
       KPP_HBLT,           &! boundary layer depth
@@ -74,7 +73,7 @@
       bckgrnd_vdc2         ! variation in diffusivity
 
    real (r8), public ::   cvmix2popL2, pop2cvmixL2
-   real (r8), public ::   cvmix2popL , pop2cvmixL 
+   real (r8), public ::   cvmix2popL , pop2cvmixL
 !EOP
 !BOC
 !-----------------------------------------------------------------------
@@ -100,10 +99,10 @@
       lccsm_control_compatible !flag for backwards compatibility with ccsm4 control
 
    character (char_len) :: &
-      langmuir_opt          ! QL, 150526, lanmguir mixing parameterization option
-                            ! valid: null, vr12-ma, vr12-en
+      langmuir_opt          ! lanmguir turbulence parameterization option
+                            ! valid: null, vr12-ma, lf17
 
-   integer (int_kind) :: & 
+   integer (int_kind) :: &
       num_v_smooth_Ri     ! num of times to vertically smooth Ri
 
    real (r8), parameter :: &
@@ -118,14 +117,14 @@
 !
 !-----------------------------------------------------------------------
 
-   real (r8), dimension(:,:,:,:,:), allocatable :: & 
+   real (r8), dimension(:,:,:,:,:), allocatable :: &
       KPP_SRC              ! non-local mixing (treated as source term)
 
 !-----------------------------------------------------------------------
 !
-!  parameters for subroutine bldepth: computes bndy layer depth 
+!  parameters for subroutine bldepth: computes bndy layer depth
 !
-!  concv   = ratio of interior buoyancy frequency to 
+!  concv   = ratio of interior buoyancy frequency to
 !            buoyancy frequency at entrainment depth
 !            parameter statement sets the minimum value.
 !
@@ -200,7 +199,7 @@
 !
 !-----------------------------------------------------------------------
 
-   real (r8), dimension(:), allocatable :: & 
+   real (r8), dimension(:), allocatable :: &
       zgrid,               &! depth at cell interfaces
       hwide                 ! layer thickness at interfaces
 
@@ -288,7 +287,7 @@
    real (r8), dimension(:,:), allocatable :: tmp_array2
 
    real (r8) ::           &
-      bckgrnd_vdc1,       &! background diffusivity (Ledwell)  
+      bckgrnd_vdc1,       &! background diffusivity (Ledwell)
       bckgrnd_vdc_eq,     &! equatorial diffusivity (Gregg)
       bckgrnd_vdc_psim,   &! Max. PSI induced diffusivity (MacKinnon)
       bckgrnd_vdc_psin,   &! PSI diffusivity in northern hemisphere
@@ -300,13 +299,6 @@
    logical (log_kind) ::  &
       lhoriz_varying_bckgrnd,  &
       larctic_bckgrnd_vdc  ! historically only used as a suboption of lniw_mixing
-  
-   ! QL, 150611, local flag for applying langmuir enhancement factor and 
-   ! enhanced entrainment in CVMix
-   logical (log_kind) ::  &
-      llangmuir_efactor,  & ! applying Langmuir enhancement factor
-      lenhanced_entrainment ! accounting for Stokes shear in the bulk 
-                            ! Richardson number
 
    namelist /vmix_kpp_nml/bckgrnd_vdc1, bckgrnd_vdc2,           &
                           bckgrnd_vdc_eq, bckgrnd_vdc_psim,     &
@@ -318,7 +310,6 @@
                           larctic_bckgrnd_vdc,                  &
                           lhoriz_varying_bckgrnd,               &
                           linertial, lcvmix, langmuir_opt
-                          ! QL, 150526, add langmuir_opt
 
    character (16), parameter :: &
       fmt_real = '(a30,2x,1pe12.5)'
@@ -331,6 +322,9 @@
 
    character (char_len) :: &
       string, string2
+
+   character (char_len) :: &
+      langmuir_mixing_opt, langmuir_entrainment_opt
 
 !-----------------------------------------------------------------------
 !
@@ -404,22 +398,21 @@
       write(stdout,fmt_log ) '  use CVMix KPP routines    =', lcvmix
 
       select case (langmuir_opt)
-      ! QL, 150612, set llangmuir_efactor and lenhanced_entrainment based on langmuir_opt 
       case ('null')
          write(stdout,'(a38)') '   no Lanmguir mixing parameterization'
-         llangmuir_efactor      = .false.
-         lenhanced_entrainment  = .false.
+         langmuir_mixing_opt      = 'NONE'
+         langmuir_entrainment_opt = 'NONE'
       case ('vr12-ma')
          write(stdout,'(a38)') '   Langmuir param. option: vr12-ma    '
-         llangmuir_efactor      = .true.
-         lenhanced_entrainment  = .false.
-      case ('vr12-en')
-         write(stdout,'(a38)') '   Langmuir param. option: vr12-en    '
-         llangmuir_efactor      = .true.
-         lenhanced_entrainment  = .true.
+         langmuir_mixing_opt      = 'LWF16'
+         langmuir_entrainment_opt = 'LWF16'
+      case ('lf17')
+         write(stdout,'(a38)') '   Langmuir param. option: lf17       '
+         langmuir_mixing_opt      = 'LWF16'
+         langmuir_entrainment_opt = 'LF17'
       case default
-         llangmuir_efactor      = .false.
-         lenhanced_entrainment  = .false.
+         langmuir_mixing_opt      = 'NONE'
+         langmuir_entrainment_opt = 'NONE'
       end select
 
    endif
@@ -443,10 +436,8 @@
    call broadcast_scalar(linertial,             master_task)
    call broadcast_scalar(lcvmix,                master_task)
    call broadcast_scalar(langmuir_opt,          master_task)
-   ! QL, 150708, broadcast llangmuir_efactor and lenhanced_entrainment
-   ! from the master_task processor to all other processors
-   call broadcast_scalar(llangmuir_efactor,     master_task)
-   call broadcast_scalar(lenhanced_entrainment, master_task)
+   call broadcast_scalar(langmuir_mixing_opt,   master_task)
+   call broadcast_scalar(langmuir_entrainment_opt, master_task)
 
    if (lcvmix) call register_string('lcvmix')
 
@@ -460,7 +451,7 @@
 
 !-----------------------------------------------------------------------
 !
-!  define some non-dimensional constants 
+!  define some non-dimensional constants
 !
 !-----------------------------------------------------------------------
 
@@ -484,7 +475,7 @@
 !-----------------------------------------------------------------------
 !
 !  define vertical grid coordinates and cell widths
-!  compute horizontally or vertically varying background 
+!  compute horizontally or vertically varying background
 !  (internal wave) diffusivity and viscosity
 !
 !  the vertical profile has the functional form
@@ -551,14 +542,14 @@
    allocate  (bckgrnd_vdc(nx_block,ny_block,km,nblocks_clinic))
 
    if (lhoriz_varying_bckgrnd) then
-   
+
      k = 1
      do iblock=1,nblocks_clinic
      do j=1,ny_block
      do i=1,nx_block
 
-      bckgrnd_vdc_psis= bckgrnd_vdc_psim*exp(-(0.4_r8*(TLATD(i,j,iblock)+28.9_r8))**c2)  
-      bckgrnd_vdc_psin= bckgrnd_vdc_psim*exp(-(0.4_r8*(TLATD(i,j,iblock)-28.9_r8))**c2)  
+      bckgrnd_vdc_psis= bckgrnd_vdc_psim*exp(-(0.4_r8*(TLATD(i,j,iblock)+28.9_r8))**c2)
+      bckgrnd_vdc_psin= bckgrnd_vdc_psim*exp(-(0.4_r8*(TLATD(i,j,iblock)-28.9_r8))**c2)
 
       bckgrnd_vdc(i,j,k,iblock)=bckgrnd_vdc_eq+bckgrnd_vdc_psin+bckgrnd_vdc_psis
 
@@ -568,14 +559,14 @@
         bckgrnd_vdc(i,j,k,iblock) = bckgrnd_vdc(i,j,k,iblock) +         &
         bckgrnd_vdc1 * (TLATD(i,j,iblock)/10.0_r8)**c2
       else
-        bckgrnd_vdc(i,j,k,iblock)=bckgrnd_vdc(i,j,k,iblock) + bckgrnd_vdc1       
+        bckgrnd_vdc(i,j,k,iblock)=bckgrnd_vdc(i,j,k,iblock) + bckgrnd_vdc1
       endif
-      
+
       !----------------
       ! North Banda Sea
       !----------------
 
-      if ( (TLATD(i,j,iblock) .lt. -1.0_r8)  .and. (TLATD(i,j,iblock) .gt. -4.0_r8)  .and.  & 
+      if ( (TLATD(i,j,iblock) .lt. -1.0_r8)  .and. (TLATD(i,j,iblock) .gt. -4.0_r8)  .and.  &
            (TLOND(i,j,iblock) .gt. 103.0_r8) .and. (TLOND(i,j,iblock) .lt. 134.0_r8)) then
            bckgrnd_vdc(i,j,k,iblock) = bckgrnd_vdc_ban
       endif
@@ -584,7 +575,7 @@
       ! Middle Banda Sea
       !-----------------
 
-      if ( (TLATD(i,j,iblock) .le. -4.0_r8)  .and. (TLATD(i,j,iblock) .gt. -7.0_r8)  .and.  & 
+      if ( (TLATD(i,j,iblock) .le. -4.0_r8)  .and. (TLATD(i,j,iblock) .gt. -7.0_r8)  .and.  &
            (TLOND(i,j,iblock) .gt. 106.0_r8) .and. (TLOND(i,j,iblock) .lt. 140.0_r8)) then
            bckgrnd_vdc(i,j,k,iblock) = bckgrnd_vdc_ban
       endif
@@ -593,7 +584,7 @@
       ! South Banda Sea
       !----------------
 
-      if ( (TLATD(i,j,iblock) .le. -7.0_r8)  .and. (TLATD(i,j,iblock) .gt. -8.3_r8)  .and.  & 
+      if ( (TLATD(i,j,iblock) .le. -7.0_r8)  .and. (TLATD(i,j,iblock) .gt. -8.3_r8)  .and.  &
            (TLOND(i,j,iblock) .gt. 111.0_r8) .and. (TLOND(i,j,iblock) .lt. 142.0_r8)) then
            bckgrnd_vdc(i,j,k,iblock) = bckgrnd_vdc_ban
       endif
@@ -637,7 +628,7 @@
         write (stdout,'(2x,e13.6)') bckgrnd_vdc(1,1,k,1)
       endif
     end do
- 
+
    endif ! lhoriz_varying_bckgrnd
 
 !-----------------------------------------------------------------------
@@ -694,14 +685,13 @@
                            KPP_Ri_zero=Riinfty,                               &
                            KPP_exp=real(3,r8))
 
-     ! QL, 150611, pass llangmuir_efactor and lenhanced_entrainment to CVMix
      call cvmix_init_kpp(lEkman=lcheckekmo,                                   &
                          lMonOb=lcheckekmo,                                   &
                          surf_layer_ext = epssfc,                             &
                          minVtsqr=c0,                                         &
                          lnoDGat1=.false.,                                    &
-                         llangmuirEF=llangmuir_efactor,                       &
-                         lenhanced_entr=lenhanced_entrainment,                &
+                         langmuir_mixing_str=langmuir_mixing_opt,             &
+                         langmuir_entrainment_str=langmuir_entrainment_opt,   &
                          MatchTechnique="MatchBoth")
      call cvmix_put_kpp("a_m", a_m)
      call cvmix_put_kpp("a_s", a_s)
@@ -747,7 +737,7 @@
              if (partial_bottom_cells) then
                CVMix_vars(ic,bid)%zt_cntr(nlev)     = (-zw(nlev-1)-p5*DZT(inx, jny, nlev, bid))*1e-2_r8
                CVMix_vars(ic,bid)%zw_iface(nlev+1)  = (-zw(nlev-1)-DZT(inx, jny, nlev, bid))*1e-2_r8
-               CVMix_vars(ic,bid)%OceanDepth        = CVMix_vars(ic,bid)%zw_iface(nlev+1) 
+               CVMix_vars(ic,bid)%OceanDepth        = CVMix_vars(ic,bid)%zw_iface(nlev+1)
              endif
              ! Initialize SchmittnerCoeff
              call cvmix_put(CVmix_vars(ic,bid), 'SchmittnerCoeff', tmp_array)
@@ -782,8 +772,7 @@
                  !--------------------------------------------------------------
                  ! form the time-invariant part of Schmittner coefficient term
                  !--------------------------------------------------------------
-                 call cvmix_compute_socn_tidal_invariant(CVmix_vars(ic,bid), &
-                                                         CVmix_params)
+                 call cvmix_compute_socn_tidal_invariant(CVmix_vars(ic,bid))
                case (tidal_mixing_method_schmittner)
                  !--------------------------------------------------------------
                  ! form the time-invariant part of Schmittner coefficient term
@@ -791,18 +780,17 @@
                  call cvmix_compute_Schmittner_invariant(CVmix_vars(ic,bid), &
                                                          CVmix_params)
                  !--------------------------------------------------------------
-                 ! form the Schmittner coefficient that is based on 3D q*E, 
+                 ! form the Schmittner coefficient that is based on 3D q*E,
                  ! which is formed from summing q_i*TidalConstituent_i over
                  ! the number of constituents.
                  !--------------------------------------------------------------
-                 call cvmix_compute_SchmittnerCoeff     (CVmix_vars(ic,bid), CVmix_params,  &
-                                                         nlev,                              &
-                                                         TIDAL_QE_3D(inx,jny,:,bid)/c1000)
+                 call cvmix_compute_SchmittnerCoeff(CVmix_vars(ic,bid),                &
+                                                    nlev,                              &
+                                                    TIDAL_QE_3D(inx,jny,:,bid)/c1000)
                  !-----------------------------------------------------------------------
                  ! form the time-invariant part of the Schmittner coefficient term
                  !-----------------------------------------------------------------------
-                 call cvmix_compute_socn_tidal_invariant(CVmix_vars(ic,bid), &
-                                                         CVmix_params)
+                 call cvmix_compute_socn_tidal_invariant(CVmix_vars(ic,bid))
               end select
              end if
            end if
@@ -813,8 +801,8 @@
 
 !-----------------------------------------------------------------------
 !
-!  define module-wide logical values to indicate which tidal-mixing 
-!    method is active. This should improve efficiency in 
+!  define module-wide logical values to indicate which tidal-mixing
+!    method is active. This should improve efficiency in
 !    subroutine ri_iwmix.
 !
 !-----------------------------------------------------------------------
@@ -867,14 +855,14 @@
                           long_name=trim(string),             &
                           units='centimeter^2/s',             &
                           grid_loc='3113',                    &
-                          coordinates  ='TLONG TLAT z_w_bot time' ) 
+                          coordinates  ='TLONG TLAT z_w_bot time' )
 
    string = 'Vertical diabatic diffusivity due to background'
    call define_tavg_field(tavg_VDC_BCK,'VDC_BCK',3,               &
                           long_name=trim(string),             &
                           units='centimeter^2/s',             &
                           grid_loc='3113',                    &
-                          coordinates  ='TLONG TLAT z_w_bot time' ) 
+                          coordinates  ='TLONG TLAT z_w_bot time' )
 
    if (ltidal_mixing) then
      string = 'Vertical viscosity due to Tidal Mixing + background'
@@ -899,7 +887,7 @@
                           long_name=trim(string),             &
                           units='erg/s/cm^3',                 &
                           grid_loc='3113',                    &
-                          coordinates  ='TLONG TLAT z_w_bot time' ) 
+                          coordinates  ='TLONG TLAT z_w_bot time' )
 
    do n = 1,nt
      string  = 'KPP_SRC_' /&
@@ -911,7 +899,7 @@
                             units=trim(tracer_d(n)%tend_units), &
                             scale_factor=tracer_d(n)%scale_factor,&
                             grid_loc='3111',                    &
-                            coordinates  ='TLONG TLAT z_t time' ) 
+                            coordinates  ='TLONG TLAT z_t time' )
    enddo
 
 
@@ -933,21 +921,21 @@
 
 ! !DESCRIPTION:
 !  This is the main driver routine which calculates the vertical
-!  mixing coefficients for the KPP mixing scheme as outlined in 
-!  Large, McWilliams and Doney, Reviews of Geophysics, 32, 363 
+!  mixing coefficients for the KPP mixing scheme as outlined in
+!  Large, McWilliams and Doney, Reviews of Geophysics, 32, 363
 !  (November 1994).  The non-local mixing is also computed here, but
 !  is treated as a source term in baroclinic.
 !
 !----------------------------------------------------------------------------------
 !  Updated late 2010/early 2011 to include near inertial wave parameterization.
-!  Final code description is as follows. We use the diffusivity k to describe 
+!  Final code description is as follows. We use the diffusivity k to describe
 !  the order of computation.
 !
-!  k is diffusivity, k_w = background, k_n = near inertial wave, k_t = tidal, 
-!  k_s = shear (Richardson), k_d = double diffusion, and k_c = convection. 
+!  k is diffusivity, k_w = background, k_n = near inertial wave, k_t = tidal,
+!  k_s = shear (Richardson), k_d = double diffusion, and k_c = convection.
 !  HBLT is boundary layer depth. The diffusivities in the description below
-!  show total combination and limits after each routine is called. k_n_max is 
-!  the maximum near inertial wave diffusivity allowed, and k_t_max is the 
+!  show total combination and limits after each routine is called. k_n_max is
+!  the maximum near inertial wave diffusivity allowed, and k_t_max is the
 !  corresponding maximum for the tidal diffusivity.
 !
 !    routine                                 description
@@ -964,9 +952,9 @@
 !      blmix            (computes k in boundary layer using present interior k)
 !      .....                   (computes interior convective mixing)
 !      .....    k = min((min(max(k_w,k_n),k_n_max) + k_t),k_t_max) + k_s + k_d + k_c
-!  
+!
 !  Thus, in words, the background diffusivity k_w is initialized first. Then the
-!  near inertial wave diffusivity is set, which is then combined with the background 
+!  near inertial wave diffusivity is set, which is then combined with the background
 !  such that when k_n is greater than the background, it is chosen; otherwise, the
 !  background is unchanged. Then, the tidal is evaluated and combined with the
 !  modified background (including near inertial wave) in a similar manner. Finally,
@@ -1032,7 +1020,7 @@
       error_string
 
    integer (int_kind) :: &
-      k,                 &! vertical level index 
+      k,                 &! vertical level index
       i,j,ic,            &! horizontal loop indices
       nlev,              &! number of levels in specific column
       n,                 &! tracer index
@@ -1056,7 +1044,7 @@
       RHO1,       &! density at surface, QL, 150526
       RHOK,       &! density at level k
       RHOKP1       ! density at level k+1
- 
+
    real (r8), dimension(nx_block,ny_block,km) :: &
       DBLOC,      &! buoyancy difference between adjacent levels
       DBSFC,      &! buoyancy difference between level and surface
@@ -1198,7 +1186,7 @@
 !
 !    compute function of Brunt-Vaisala squared for convection.
 !
-!  use either a smooth    
+!  use either a smooth
 !
 !    WORK1 = N**2,  FCON is function of N**2
 !    FCON = 0 for N**2 > 0
@@ -1208,7 +1196,7 @@
 !  or a step function. The smooth function has been used with
 !  BVSQcon = -0.2e-4_dbl_kind.
 !
-!  after convection, average viscous coeffs to U-grid and reset sea 
+!  after convection, average viscous coeffs to U-grid and reset sea
 !  floor values
 !
 !-----------------------------------------------------------------------
@@ -1254,7 +1242,7 @@
      enddo
    end if
 
-   do k=1,km-1           
+   do k=1,km-1
      !*** add convection and reset sea floor values to zero
      where (k < KMT(:,:,bid))
         VISC(:,:,k  ) = VISC(:,:,k)   + CONV_VVC(:,:,k)
@@ -1266,7 +1254,7 @@
         VDC (:,:,k,2) = c0
      end where
 
-      !*** now average visc to U grid 
+      !*** now average visc to U grid
       if (l1Ddyn) then
         VVC(:,:,k) = merge(VISC(:,:,k), c0, (k < KMU(:,:,bid)))
       else
@@ -1281,7 +1269,7 @@
 
 !-----------------------------------------------------------------------
 !
-!  add ghatp term from previous computation to right-hand-side 
+!  add ghatp term from previous computation to right-hand-side
 !  source term on current row
 !
 !-----------------------------------------------------------------------
@@ -1323,7 +1311,7 @@
 
 !-----------------------------------------------------------------------
 !
-!  compute diagnostic mixed layer depth (cm) using a max buoyancy 
+!  compute diagnostic mixed layer depth (cm) using a max buoyancy
 !  gradient criterion.  Use USTAR and BFSFC as temps.
 !
 !-----------------------------------------------------------------------
@@ -1396,8 +1384,8 @@
 
 !-----------------------------------------------------------------------
 !
-!  compute diagnostic mixed layer depth (cm) using a fixed density 
-!  threshold criterion (offset = 0.03 kg/m^3 = 3e-5 g/cm^3) 
+!  compute diagnostic mixed layer depth (cm) using a fixed density
+!  threshold criterion (offset = 0.03 kg/m^3 = 3e-5 g/cm^3)
 !  QL, 150526
 !
 !-----------------------------------------------------------------------
@@ -1405,7 +1393,7 @@
    FLGMOD = 0 ! flag of status, 1=found
    where (KMT(:,:,bid) == 1)
       HMXL_DR(:,:,bid) = zt(1)
-      FLGMOD = 1    ! mark as found 
+      FLGMOD = 1    ! mark as found
    elsewhere
       HMXL_DR(:,:,bid) = c0
    endwhere
@@ -1423,7 +1411,7 @@
       where (WORK2 > RHOK .and. WORK2 <= RHOKP1 .and. FLGMOD == 0)
       HMXL_DR(:,:,bid) = zt(k) + (WORK2-RHOK) &
                           * (zt(k+1)-zt(k)) / (RHOKP1-RHOK+eps)
-         FLGMOD = 1    ! mark as found 
+         FLGMOD = 1    ! mark as found
       endwhere
       RHOK = RHOKP1
    enddo
@@ -1452,7 +1440,7 @@
    real (r8), dimension(nx_block,ny_block,km), intent(in) :: &
       UUU               ! U velocities at current time
 
-   real (r8), dimension(nx_block,ny_block,km), intent(in) :: & 
+   real (r8), dimension(nx_block,ny_block,km), intent(in) :: &
       VVV,             &! V velocities at current time
       DBLOC             ! buoyancy difference between adjacent levels
 
@@ -1466,10 +1454,10 @@
 
    type(cvmix_data_type), dimension(:), intent(inout) :: CVmix_vars
 
-   real (r8), dimension(nx_block,ny_block,0:km+1,2), intent(inout) :: & 
+   real (r8), dimension(nx_block,ny_block,0:km+1,2), intent(inout) :: &
       VDC        ! diffusivity for tracer diffusion
 
-   real (r8), dimension(nx_block,ny_block,0:km+1), intent(inout) :: & 
+   real (r8), dimension(nx_block,ny_block,0:km+1), intent(inout) :: &
       VISC       ! viscosity
 
    logical (log_kind), parameter :: &
@@ -1494,14 +1482,14 @@
    real (r8), dimension(0:km+1) :: VISC_COL, DIFF_COL
 
    real (r8), dimension(nx_block,ny_block,0:km+1) :: &
-      WORK0               ! work array 
+      WORK0               ! work array
 
    real (r8), dimension(nx_block,ny_block,km) :: &
       KVMIX,             &! vertical diffusivity
       KVMIX_M,           &! vertical viscosity
       FRI,               &! function of Ri for shear
       VSHEAR,            &! (local velocity shear)^2
-      RI_LOC              ! local Richardson number 
+      RI_LOC              ! local Richardson number
 
    real (r8), dimension(nx_block,ny_block) :: &
       FCON,              &
@@ -1511,7 +1499,7 @@
       ZSTARP_INV          ! c1/z^*_sub p
 
    real (r8) :: N2_AVG_clmn, ZSTARP_INV_clmn
- 
+
 
 !-----------------------------------------------------------------------
 !
@@ -1577,7 +1565,7 @@
       end if
 
       WORK0(:,:,k)   = merge(RI_LOC(:,:,k), WORK0(:,:,k-1), k <= KMT(:,:,bid))
- 
+
    enddo
 
 !-----------------------------------------------------------------------
@@ -1587,12 +1575,12 @@
 !  as temps
 !
 !-----------------------------------------------------------------------
- 
+
    do n = 1,num_v_smooth_Ri
- 
+
       WORK1          =  p25 * WORK0(:,:,1)
       WORK0(:,:,km+1) =       WORK0(:,:,km)
- 
+
       do k=1,km
          !!!DIR$ NODEP
          do j=1,ny_block
@@ -1631,10 +1619,10 @@
        do i=1,nx_block
 
           if ( ltidal_mixing ) then
-            !*** if using tidal_mixing option, compute some full-depth quantites 
+            !*** if using tidal_mixing option, compute some full-depth quantites
             !    before looping over k
             !*** this should be imported to cvmix_tidal
-            
+
              if (luse_polzin) then
                !*** note: polzin method is colmnized, but not cvmix-ified. Note
                !    that units in the polzin computaton are native POP units,
@@ -1656,14 +1644,14 @@
             if (lniw_mixing) then
               VISC_COL(1:nlev) = VISC(i,j,1:nlev-1)
               DIFF_COL(1:nlev) = VDC(i,j,1:nlev-1,2)
-            else 
+            else
               VISC_COL(1:nlev) = bckgrnd_vvc(i,j,1,bid)
               DIFF_COL(1:nlev) = bckgrnd_vdc(i,j,1,bid)
             end if
 
             if (ltidal_mixing) then
                if (luse_simmons) then
-               !*** compute tidal diffusion 
+               !*** compute tidal diffusion
                  if (ltidal_lunar_cycle) then
                   call cvmix_compute_Simmons_invariant  &
                     (CVmix_vars(ic), CVmix_params, TIDAL_QE_2D(i,j,bid)/c1000)
@@ -1674,10 +1662,10 @@
                                          CVmix_params)
 
                else if (luse_schmittner) then
-               !*** compute tidal diffusion 
+               !*** compute tidal diffusion
                  if (ltidal_lunar_cycle) then
-                  call cvmix_compute_SchmittnerCoeff (CVmix_vars(ic), CVmix_params, nlev, &
-                                                      TIDAL_QE_3D(i,j,:,bid)/c1000)
+                  call cvmix_compute_SchmittnerCoeff(CVmix_vars(ic), nlev, &
+                                                     TIDAL_QE_3D(i,j,:,bid)/c1000)
                  endif
                  call cvmix_coeffs_tidal(CVmix_vars(ic), &
                                          CVmix_params)
@@ -1696,7 +1684,7 @@
               if (ltidal_stabc .and. .not. lccsm_control_compatible) then
                 do k= KMT(i,j,bid) - 2, KMT(i,j,bid) - 1
                   if (k.gt.2) &
-                  CVMix_vars(ic)%Tdiff_iface(k+1) = max( & 
+                  CVMix_vars(ic)%Tdiff_iface(k+1) = max( &
                     CVMix_vars(ic)%Tdiff_iface(k+1),CVMix_vars(ic)%Tdiff_iface(k))
                 enddo
               endif ! ltidal_mixing
@@ -1762,7 +1750,7 @@
 
 !-----------------------------------------------------------------------
 !
-!  if using tidal_mixing option, compute some full-depth quantites 
+!  if using tidal_mixing option, compute some full-depth quantites
 !   before looping over k
 !
 !-----------------------------------------------------------------------
@@ -1861,7 +1849,7 @@
               VDC(:,:,k,1) = VDC(:,:,k,2)
             endif
           else
-            VISC(:,:,k) = WORK1 
+            VISC(:,:,k) = WORK1
 
             if ( k < km ) then
               VDC(:,:,k,1) = VDC(:,:,k,2)
@@ -1893,7 +1881,7 @@
              endif
           endif
 
-          else 
+          else
           if (lrich) then
              VISC(:,:,k  ) = bckgrnd_vvc(:,:,k,bid) + &
                              rich_mix*(c1 - FRI(:,:,k)*FRI(:,:,k))**3
@@ -1946,7 +1934,7 @@
      ! while output axis is at cell top
      call accumulate_tavg_field(KVMIX(:,:,k),tavg_KVMIX,bid,k)
      call accumulate_tavg_field(KVMIX_M(:,:,k),tavg_KVMIX_M,bid,k)
-     
+
      if (lniw_mixing) then
      !*** accumulated in iw_reset
      else
@@ -1955,7 +1943,7 @@
        call accumulate_tavg_field(bckgrnd_vdc(:,:,k,bid),tavg_VDC_BCK,bid,k)
        call accumulate_tavg_field(bckgrnd_vvc(:,:,k,bid),tavg_VVC_BCK,bid,k)
      endif
- 
+
      if (accumulate_tavg_now(tavg_TPOWER)) then
        WORK1(:,:) = KVMIX(:,:,k)*RHOMIX(:,:,k)*DBLOC(:,:,k)/(zgrid(k)-zgrid(k+1))
        call accumulate_tavg_field(WORK1,tavg_TPOWER,bid,k)
@@ -2003,7 +1991,7 @@
 
 !-----------------------------------------------------------------------
 !EOC
- 
+
  end subroutine ri_iwmix
 
 !***********************************************************************
@@ -2020,15 +2008,15 @@
 !  the shallowest depth where the bulk Richardson number is equal to
 !  a critical value, Ricr.
 !
-!  NOTE: bulk richardson numbers are evaluated by computing 
+!  NOTE: bulk richardson numbers are evaluated by computing
 !        differences between values at zgrid(kl) $< 0$ and surface
-!        reference values. currently, the reference values are equal 
-!        to the values in the surface layer.  when using higher 
-!        vertical grid resolution, these reference values should be 
-!        computed as the vertical averages from the surface down to 
+!        reference values. currently, the reference values are equal
+!        to the values in the surface layer.  when using higher
+!        vertical grid resolution, these reference values should be
+!        computed as the vertical averages from the surface down to
 !        epssfc*zgrid(kl).
 !
-!  This routine also computes where surface forcing is stable 
+!  This routine also computes where surface forcing is stable
 !  or unstable (STABLE)
 !
 ! !REVISION HISTORY:
@@ -2127,7 +2115,7 @@
 
    real (r8) :: &
       a_co, b_co, c_co    ! coefficients of the quadratic equation
-                          ! $(a_{co}z^2+b_{co}|z|+c_{co}=Ri_b) used to 
+                          ! $(a_{co}z^2+b_{co}|z|+c_{co}=Ri_b) used to
                           ! find the boundary layer depth. when
                           ! finding the roots, c_co = c_co - Ricr
 
@@ -2196,10 +2184,10 @@
 !  max values when Ricr never satisfied are KBL = KMT and
 !  HBLT = -zgrid(KMT)
 !
-!  NOTE: the reference depth is -epssfc/2.*zgrid(i,k), but the 
-!        reference u,v,t,s values are simply the surface layer 
+!  NOTE: the reference depth is -epssfc/2.*zgrid(i,k), but the
+!        reference u,v,t,s values are simply the surface layer
 !        values and not the averaged values from 0 to 2*ref.depth,
-!        which is necessary for very fine grids(top layer < 2m 
+!        which is necessary for very fine grids(top layer < 2m
 !        thickness)
 !
 !
@@ -2217,7 +2205,7 @@
    z_up    = zgrid(1)
 
    RI_BULK(:,:,kupper) = c0
-   RI_BULK(:,:,kup) = c0 
+   RI_BULK(:,:,kup) = c0
    KBL = merge(KMT(:,:,bid), 1, (KMT(:,:,bid) > 1))
 
    do kl=1,km
@@ -2251,7 +2239,7 @@
          case ('top-layer')
 
             BFSFC = BO + BOSOL
-         
+
          case ('jerlov')
 
             call sw_absorb_frac(-z_up,absorb_frac)
@@ -2289,7 +2277,7 @@
 ! account for the unresolved part of the NI velocity (equal to the resolved); Markus 9/27/11
 ! the 0.05 accounts like in En for the average over the abs(cycle), loosely based on
 ! 1/T * integral(cos), also tuned to get En = u'Tau' from model
-! Model resolves half NI energy, so the unresolved part, nivel is added again 
+! Model resolves half NI energy, so the unresolved part, nivel is added again
 ! x4 because for 16 hours 1/f a time step of 1 hours gets only a quarter of max. increase
 
    if ( lniw_mixing .and. linertial ) then
@@ -2300,11 +2288,11 @@
          nivel(i,j)=c0
 
          if( TLATD(i,j,bid) > 5.0_r8 ) then
- 
+
           factor = ni_obs_factor*abs(12.0_r8*3600.0_r8/sin(TLAT(i,j,bid)))/pi2/dtt
-          niuel(i,j) = - factor * (VCUR(i,j,1) - VVV(i,j,1))     
-          nivel(i,j) =   factor * (UCUR(i,j,1) - UUU(i,j,1))     
-    
+          niuel(i,j) = - factor * (VCUR(i,j,1) - VVV(i,j,1))
+          nivel(i,j) =   factor * (UCUR(i,j,1) - UUU(i,j,1))
+
            if( TLATD(i,j,bid) < 10.0_r8 ) then
             niuel(i,j) = niuel(i,j) * NIW_COS_FACTOR(i,j,bid)
             nivel(i,j) = nivel(i,j) * NIW_COS_FACTOR(i,j,bid)
@@ -2316,8 +2304,8 @@
          if( TLATD(i,j,bid) < -5.0_r8 ) then
 
           factor = ni_obs_factor*abs(12.0_r8*3600.0_r8/sin(TLAT(i,j,bid)))/pi2/dtt
-          niuel(i,j) =   factor * (VCUR(i,j,1) - VVV(i,j,1))     
-          nivel(i,j) = - factor * (UCUR(i,j,1) - UUU(i,j,1))     
+          niuel(i,j) =   factor * (VCUR(i,j,1) - VVV(i,j,1))
+          nivel(i,j) = - factor * (UCUR(i,j,1) - UUU(i,j,1))
 
            if( TLATD(i,j,bid) > -10.0_r8 ) then
             niuel(i,j) = niuel(i,j) * NIW_COS_FACTOR(i,j,bid)
@@ -2333,7 +2321,7 @@
 
    do kl = 2,km
 
-      ! Determine which layer contains surface layer (epssfc*zt(kl)) 
+      ! Determine which layer contains surface layer (epssfc*zt(kl))
       SURFTHICK = epssfc*zt(kl)
       kref = kl
       do ktmp = 1,kl
@@ -2362,14 +2350,14 @@
 
       if ( lniw_mixing ) then
         WORK = (UREF + niuel(:,:) - UUU(:,:,kl))**2 + &
-               (VREF + nivel(:,:) - VVV(:,:,kl))**2 
+               (VREF + nivel(:,:) - VVV(:,:,kl))**2
       else
         WORK = (UREF - UUU(:,:,kl))**2 + &
                (VREF - VVV(:,:,kl))**2
       endif
-     
+
       if (partial_bottom_cells) then
-         WORK = WORK/(-zgrid(kl-1) + & 
+         WORK = WORK/(-zgrid(kl-1) + &
                       p5*(DZU(:,:,kl  ,bid) + &
                           DZU(:,:,kl-1,bid) - &
                           DZU(:,:,1   ,bid)))**2
@@ -2409,7 +2397,7 @@
            do j=1,ny_block
            do i=1,nx_block
               call sw_absorb_frac(ZKL(i,j), absorb_frac)
-              BFSFC(i,j) = BO(i,j) + BOSOL(i,j)*(c1 - absorb_frac) 
+              BFSFC(i,j) = BO(i,j) + BOSOL(i,j)*(c1 - absorb_frac)
            enddo
            enddo
 
@@ -2472,8 +2460,7 @@
 !-----------------------------------------------------------------------
 
       SIGMA = epssfc
-      
-      ! QL, 150706, calculate WS with CVMix if lcvmix is true
+
       if (lcvmix) then
         do j = 1,ny_block
           do i = 1,nx_block
@@ -2481,7 +2468,6 @@
                         ZKL(i,j)*1e-2_r8,                &
                         BFSFC(i,j)*1e-4_r8,        &
                         USTAR(i,j)*1e-2_r8,          &
-                        langmuir_Efactor=LAMULT(i,j,bid),     &
                         w_s=WS(i,j))
             WS(i,j) = WS(i,j)*1e2_r8
           end do
@@ -2520,22 +2506,17 @@
           do i = 1,nx_block
             ic = (j-1)*nx_block + i
             if (kl.le.CVmix_vars(ic)%nlev) then
-              WM(i,j:j) = cvmix_kpp_compute_unresolved_shear(                 &
-                          zt_cntr = (/zgrid(kl)/)*1e-2_r8,                    &
-                          ws_cntr = (/WS(i,j)/)*1e-2_r8,                      &
-                          N_iface = (/B_FRQNCY(i,j), B_FRQNCY(i,j)/))*1e4_r8
-              ! QL, 150611, pass in stokes_drift
               RI_BULK(i,j,kdn:kdn) = cvmix_kpp_compute_bulk_Richardson(       &
                           zt_cntr = (/zgrid(kl)/)*1e-2_r8,                    &
+                          ws_cntr = (/WS(i,j)/)*1e-2_r8,                      &
                           delta_buoy_cntr = (/DBSFC(i,j,kl)/)*1e-2_r8,        &
                           delta_Vsqr_cntr = (/VSHEAR(i,j)/)*1e-4_r8,          &
-                          Vt_sqr_cntr = (/WM(i,j)/)*1e-4_r8,                  &
-                         stokes_drift =                                       &
-                           sqrt(USTOKES(i,j,bid)**2+VSTOKES(i,j,bid)**2))
+                          N_iface = (/B_FRQNCY(i,j), B_FRQNCY(i,j)/),         &
+                          EFactor = LAMULT(i,j,bid))
             else
 
 !-----------------------------------------------------------------------
-! 
+!
 !     compute bulk Richardson number at new level
 !
 !-----------------------------------------------------------------------
@@ -2548,7 +2529,7 @@
       else
 
 !-----------------------------------------------------------------------
-! 
+!
 !     compute bulk Richardson number at new level
 !
 !-----------------------------------------------------------------------
@@ -2560,7 +2541,7 @@
            WORK = merge( DBSFC(:,:,kl)/(-zgrid(kl-1)+            &
                                         p5*(DZT(:,:,kl-1,bid) +  &
                                             DZT(:,:,kl  ,bid) -  &
-                                            DZT(:,:,1   ,bid))), & 
+                                            DZT(:,:,1   ,bid))), &
                          c0, KMT(:,:,bid) >= kl)
            WM = WM/(-zgrid(kl-1) +          &
                     p5*(DZT(:,:,kl-1,bid) + &
@@ -2594,7 +2575,7 @@
 !       Ri_bulk at z_up and Ri_bulk at zgrid(kl). the slope at
 !       z_up is computed linearly between z_upper and z_up.
 !
-!       compute Langmuir depth always 
+!       compute Langmuir depth always
 !-----------------------------------------------------------------------
 
          do j=1,ny_block
@@ -2626,7 +2607,7 @@
                else
                   HBLT(i,j) = (-b_co + sqrt(sqrt_arg)) / (c2*a_co)
                endif
-            
+
                KBL(i,j) = kl
              end if
              RSH_HBLT(i,j) =  (VSHEAR(i,j)*Ricr(kl)/ &
@@ -2720,7 +2701,7 @@
          do j = 1,ny_block
          do i = 1,nx_block
             call sw_absorb_frac(HBLT(i,j),absorb_frac)
-            BFSFC(i,j)  = BO(i,j) + BOSOL(i,j)*(c1 - absorb_frac) 
+            BFSFC(i,j)  = BO(i,j) + BOSOL(i,j)*(c1 - absorb_frac)
          enddo
          enddo
 
@@ -2763,16 +2744,16 @@
 ! !INTERFACE:
 
  subroutine blmix(CVmix_vars, VISC, VDC, HBLT, USTAR, BFSFC, STABLE, &
-                  KBL, GHAT, GHAT2, this_block) 
+                  KBL, GHAT, GHAT2, this_block)
 
 ! !DESCRIPTION:
-!  This routine computes mixing coefficients within boundary layer 
-!  which depend on surface forcing and the magnitude and gradient 
+!  This routine computes mixing coefficients within boundary layer
+!  which depend on surface forcing and the magnitude and gradient
 !  of interior mixing below the boundary layer (matching).  These
 !  quantities have been computed in other routines.
 !
 !  Caution: if mixing bottoms out at hbl = -zgrid(km) then
-!  fictitious layer at km+1 is needed with small but finite width 
+!  fictitious layer at km+1 is needed with small but finite width
 !  hwide(km+1).
 !
 ! !REVISION HISTORY:
@@ -2782,7 +2763,7 @@
 
    type(cvmix_data_type), dimension(:), intent(inout) :: CVmix_vars
 
-   real (r8), dimension(nx_block,ny_block,0:km+1), intent(inout) :: & 
+   real (r8), dimension(nx_block,ny_block,0:km+1), intent(inout) :: &
       VISC               ! interior mixing coeff on input
                          ! combined interior/bndy layer coeff output
 
@@ -2832,12 +2813,12 @@
 
    real (r8), dimension(nx_block,ny_block,3) :: &
       GAT1,              &! shape function at sigma=1
-      DAT1,              &! derivative of shape function 
+      DAT1,              &! derivative of shape function
       DKM1                ! bndy layer difs at kbl-1 lvl
 
    real (r8), dimension(nx_block,ny_block) :: &
       WM,WS,             &! turbulent velocity scales
-      CASEA,             &! =1 in case A, =0 in case B     
+      CASEA,             &! =1 in case A, =0 in case B
       SIGMA,             &! normalized depth (d/hbl)
       VISCH,             &! viscosity at hbl
       DIFTH,             &! temp diffusivity at hbl
@@ -2881,10 +2862,7 @@
            CVmix_vars(ic)%kOBL_depth = real(KBL(i,j),r8)+p5*(p5-CASEA(i,j))
            CVmix_vars(ic)%SurfaceFriction = USTAR(i,j)*1e-2_r8
            CVmix_vars(ic)%SurfaceBuoyancyForcing = BFSFC(i,j)*1e-4_r8
-           ! QL, 150612, set langmuir enhancement factor and stokes drift
            CVmix_vars(ic)%LangmuirEnhancementFactor = LAMULT(i,j,bid)
-           CVmix_vars(ic)%SurfaceStokesDrift =   &
-                            sqrt(USTOKES(i,j,bid)**2+VSTOKES(i,j,bid)**2)
 
            call cvmix_coeffs_kpp(CVmix_vars(ic))
 
@@ -2936,9 +2914,9 @@
 
 !-----------------------------------------------------------------------
 !
-!  find the interior viscosities and derivatives at hbl by 
+!  find the interior viscosities and derivatives at hbl by
 !  interpolating derivative values at vertical interfaces.  compute
-!  matching conditions for shape function.  
+!  matching conditions for shape function.
 !
 !-----------------------------------------------------------------------
 
@@ -2950,7 +2928,7 @@
 
            if (k == 1) then
               WORK1 = c0
-           else            
+           else
               WORK1 = DZT(:,:,k-1,bid)
            end if
            if (k == km) then
@@ -2965,7 +2943,7 @@
               if (k == KN(i,j)) then
 
               DELHAT(i,j) = - zgrid(k-1) + DZT(i,j,k,bid) + &
-                              p5*WORK1(i,j) - HBLT(i,j)  
+                              p5*WORK1(i,j) - HBLT(i,j)
               R     (i,j) = c1 - DELHAT(i,j) /DZT(i,j,k,bid)
 
               DVDZUP(i,j) = (VISC(i,j,k-1) - VISC(i,j,k  ))/DZT(i,j,k,bid)
@@ -3013,7 +2991,7 @@
            do i=1,nx_block
               if (k == KN(i,j)) then
 
-              DELHAT(i,j) = p5*hwide(k) - zgrid(k) - HBLT(i,j)        
+              DELHAT(i,j) = p5*hwide(k) - zgrid(k) - HBLT(i,j)
               R     (i,j) = c1 - DELHAT(i,j) / hwide(k)
 
               DVDZUP(i,j) = (VISC(i,j,k-1) - VISC(i,j,k  ))/hwide(k)
@@ -3036,7 +3014,7 @@
                                  (DVDZUP(i,j) + abs(DVDZUP(i,j))) + &
                                      R(i,j) * &
                                  (DVDZDN(i,j) + abs(DVDZDN(i,j))) )
-   
+
               VISCH(i,j) = VISC(i,j,k)  + VISCP(i,j)*DELHAT(i,j)
               DIFSH(i,j) = VDC(i,j,k,2) + DIFSP(i,j)*DELHAT(i,j)
               DIFTH(i,j) = VDC(i,j,k,1) + DIFTP(i,j)*DELHAT(i,j)
@@ -3071,17 +3049,17 @@
 !
 !-----------------------------------------------------------------------
 
-     do k = 1,km       
+     do k = 1,km
 
         if (partial_bottom_cells) then
            if (k > 1) then
               SIGMA = (-zgrid(k-1) + p5*DZT(:,:,k-1,bid) +  &
-                       DZT(:,:,k,bid)) / HBLT 
+                       DZT(:,:,k,bid)) / HBLT
            else
-              SIGMA = (-zgrid(k) + p5*hwide(k)) / HBLT     
+              SIGMA = (-zgrid(k) + p5*hwide(k)) / HBLT
            end if
         else
-           SIGMA = (-zgrid(k) + p5*hwide(k)) / HBLT     
+           SIGMA = (-zgrid(k) + p5*hwide(k)) / HBLT
         endif
         F1 = min(SIGMA,epssfc)
 
@@ -3093,13 +3071,13 @@
            BLMC(i,j,k,1) = HBLT(i,j)*WM(i,j)*SIGMA(i,j)*       &
                            (c1 + SIGMA(i,j)*((SIGMA(i,j)-c2) + &
                            (c3-c2*SIGMA(i,j))*GAT1(i,j,1) +    &
-                           (SIGMA(i,j)-c1)*DAT1(i,j,1))) 
+                           (SIGMA(i,j)-c1)*DAT1(i,j,1)))
            BLMC(i,j,k,2) = HBLT(i,j)*WS(i,j)*SIGMA(i,j)*       &
                            (c1 + SIGMA(i,j)*((SIGMA(i,j)-c2) + &
                            (c3-c2*SIGMA(i,j))*GAT1(i,j,2) +    &
                            (SIGMA(i,j)-c1)*DAT1(i,j,2)))
            BLMC(i,j,k,3) = HBLT(i,j)*WS(i,j)*SIGMA(i,j)*       &
-                           (c1 + SIGMA(i,j)*((SIGMA(i,j)-c2) + &    
+                           (c1 + SIGMA(i,j)*((SIGMA(i,j)-c2) + &
                            (c3-c2*SIGMA(i,j))*GAT1(i,j,3) +    &
                            (SIGMA(i,j)-c1)*DAT1(i,j,3)))
 
@@ -3119,11 +3097,11 @@
      do j=1,ny_block
      do i=1,nx_block
         k = KBL(i,j) - 1
-        SIGMA(i,j) = -zgrid(k)/HBLT(i,j)          
+        SIGMA(i,j) = -zgrid(k)/HBLT(i,j)
      enddo
      enddo
 
-     F1 = min(SIGMA,epssfc)        
+     F1 = min(SIGMA,epssfc)
      call wscale(F1, HBLT, USTAR, BFSFC, 3, WM, WS)
 
      !!!DIR$ COLLAPSE
@@ -3138,7 +3116,7 @@
                       (c3-c2*SIGMA(i,j))*GAT1(i,j,2) +  &
                       (SIGMA(i,j)-c1)*DAT1(i,j,2)))
         DKM1(i,j,3) = HBLT(i,j)*WS(i,j)*SIGMA(i,j)*     &
-                      (c1+SIGMA(i,j)*((SIGMA(i,j)-c2) + &       
+                      (c1+SIGMA(i,j)*((SIGMA(i,j)-c2) + &
                       (c3-c2*SIGMA(i,j))*GAT1(i,j,3) +  &
                       (SIGMA(i,j)-c1)*DAT1(i,j,3)))
      end do
@@ -3154,7 +3132,7 @@
      do k=1,km-1
 
         if (partial_bottom_cells) then
-           if (k == 1) then 
+           if (k == 1) then
               WORK1 = -p5*DZT(:,:,k,bid)
            else
               WORK1 = zgrid(k-1) - p5*(DZT(:,:,k-1,bid) + &
@@ -3210,7 +3188,7 @@
         do j=1,ny_block
         !!!DIR$ NODEP
         do i=1,nx_block
-           if (k < KBL(i,j)) then 
+           if (k < KBL(i,j)) then
               VISC(i,j,k)  = BLMC(i,j,k,1)
               VDC(i,j,k,2) = BLMC(i,j,k,2)
               VDC(i,j,k,1) = BLMC(i,j,k,3)
@@ -3237,19 +3215,19 @@
 ! !DESCRIPTION:
 !  Computes turbulent velocity scales.
 !
-!  For $\zeta \geq 0, 
+!  For $\zeta \geq 0,
 !    w_m = w_s = \kappa U^\star/(1+5\zeta)$
 !
-!  For $\zeta_m \leq \zeta < 0, 
+!  For $\zeta_m \leq \zeta < 0,
 !    w_m = \kappa U^\star (1-16\zeta)^{1\over 4}$
 !
-!  For $\zeta_s \leq \zeta < 0, 
+!  For $\zeta_s \leq \zeta < 0,
 !    w_s = \kappa U^\star (1-16\zeta)^{1\over 2}$
 !
-!  For $\zeta < \zeta_m, 
+!  For $\zeta < \zeta_m,
 !    w_m = \kappa U^\star (a_m - c_m\zeta)^{1\over 3}$
 !
-!  For $\zeta < \zeta_s, 
+!  For $\zeta < \zeta_s,
 !    w_s = \kappa U^\star (a_s - c_s\zeta)^{1\over 3}$
 !
 !  where $\kappa$ is the von Karman constant.
@@ -3525,7 +3503,7 @@
 
 ! !OUTPUT PARAMETERS:
 
-   real (r8), dimension(nx_block,ny_block,km), intent(out) :: & 
+   real (r8), dimension(nx_block,ny_block,km), intent(out) :: &
       DBLOC,         &! buoyancy difference between adjacent levels
       DBSFC           ! buoyancy difference between level and surface
 
@@ -3634,7 +3612,7 @@
  subroutine add_kpp_sources(SRCARRAY, k, this_block)
 
 ! !DESCRIPTION:
-!  This routine adds KPP non local mixing term to the tracer source 
+!  This routine adds KPP non local mixing term to the tracer source
 !  tendencies.
 !
 ! !REVISION HISTORY:
@@ -3757,34 +3735,34 @@
 
 !-----------------------------------------------------------------------
 !
-!     consistency checks 
+!     consistency checks
 !
 !-----------------------------------------------------------------------
 
    if ( overwrite_hblt  .and.  ( .not.present(KBL)  .or.        &
-                                 .not.present(HBLT) ) ) then      
+                                 .not.present(HBLT) ) ) then
      message = 'incorrect subroutine arguments for smooth_hblt, error # 1'
      call exit_POP (sigAbort, trim(message))
    endif
 
-   if ( .not.overwrite_hblt  .and.  .not.present(SMOOTH_OUT) ) then 
+   if ( .not.overwrite_hblt  .and.  .not.present(SMOOTH_OUT) ) then
      message = 'incorrect subroutine arguments for smooth_hblt, error # 2'
      call exit_POP (sigAbort, trim(message))
    endif
 
-   if ( use_hmxl .and. .not.present(SMOOTH_OUT) ) then          
+   if ( use_hmxl .and. .not.present(SMOOTH_OUT) ) then
      message = 'incorrect subroutine arguments for smooth_hblt, error # 3'
      call exit_POP (sigAbort, trim(message))
    endif
 
-   if ( overwrite_hblt  .and.  use_hmxl ) then                  
+   if ( overwrite_hblt  .and.  use_hmxl ) then
      message = 'incorrect subroutine arguments for smooth_hblt, error # 4'
      call exit_POP (sigAbort, trim(message))
    endif
 
 !-----------------------------------------------------------------------
 !
-!     perform one smoothing pass since we cannot do the necessary 
+!     perform one smoothing pass since we cannot do the necessary
 !     boundary updates for multiple passes.
 !
 !-----------------------------------------------------------------------
@@ -3866,7 +3844,7 @@
            if ( KMT(i,j,bid) /= 0            .and.  &
                 ( HBLT(i,j) >  -zgrid(k-1) ) .and.  &
                 ( HBLT(i,j) <= ztmp        ) ) KBL(i,j) = max(k,2)
-     
+
          enddo
        enddo
      enddo
@@ -3901,7 +3879,7 @@
       UCUR,VCUR    ! velocities at current time
 
    real (r8), dimension(nx_block,ny_block), intent(in) :: &
-      KPP_HBLT   
+      KPP_HBLT
 
    type (block), intent(in) :: &
       this_block   ! block information for current block
@@ -3973,7 +3951,7 @@
 !  compute En for boundary layer KE, enforcing positivity. En is the
 !  energy flux for generating near-inertial waves. Note, the factor
 !  multiplying the kinetic energy (KE) tendency is an empirical scaling
-!  factor to map the total time-step change in boundary layer kinetic 
+!  factor to map the total time-step change in boundary layer kinetic
 !  energy into that fraction which generates near-inertial waves.
 !-----------------------------------------------------------------------
 
@@ -4004,15 +3982,15 @@
        enddo
 
 !-----------------------------------------------------------------------
-!  write En for boundary layer KE to history file, converting 
+!  write En for boundary layer KE to history file, converting
 !  erg/cm2/sec to Watts/m2
 !-----------------------------------------------------------------------
 
        call accumulate_tavg_field(En/c1000,tavg_En,bid,1)
 
 !-----------------------------------------------------------------------
-!  include other factors for niw parameterization in final definition 
-!  of En. These other factors account for various fractions of En that 
+!  include other factors for niw parameterization in final definition
+!  of En. These other factors account for various fractions of En that
 !  result in diffusivity forming mixing in the column.
 !-----------------------------------------------------------------------
 
@@ -4140,10 +4118,10 @@
 ! !INPUT PARAMETERS:
 ! !INPUT/OUTPUT PARAMETERS:
 
-   real (r8), dimension(nx_block,ny_block,0:km+1), intent(inout) :: & 
+   real (r8), dimension(nx_block,ny_block,0:km+1), intent(inout) :: &
       VISC       ! viscosity
 
-   real (r8), dimension(nx_block,ny_block,0:km+1,2), intent(inout) :: & 
+   real (r8), dimension(nx_block,ny_block,0:km+1,2), intent(inout) :: &
       VDC        ! diffusivity for tracer diffusion
 
    type (block), intent(in) :: &
@@ -4191,12 +4169,12 @@
 
    VISC(:,:,0  ) = c0
    VDC (:,:,0,:) = c0
-   VISC(:,:,km+1  ) = c0 
-   VDC (:,:,km+1,:) = c0 
+   VISC(:,:,km+1  ) = c0
+   VDC (:,:,km+1,:) = c0
 
 !-----------------------------------------------------------------------
 !EOC
- 
+
  end subroutine iw_reset
 
 !***********************************************************************


### PR DESCRIPTION
### Description of changes:

This pull request enables the parameterization of Langmuir turbulence induced entrainment by [Li and Fox-Kemper (2017)](https://doi.org/10.1175/JPO-D-17-0085.1) via CVMix. It includes the following changes:
 - Point the CVMix repository to v0.97b-beta and update the CVMix interface in POP. A new interface of Langmuir turbulence parameterizations in CVMix was introduced in CVMix v0.94b-beta, allowing more options including Langmuir induced entrainment. See [this PR](https://github.com/CVMix/CVMix-src/pull/74) for more information.
- Get the surface layer averaged Langmuir number `LaSL` from WAVEWATCH III for Langmuir induced entrainment.

### Testing:
 
Test case/suite: See below
Test status: climate changing

Fixes [POP2 Github issue #]: N/A

User interface (namelist or namelist defaults) changes?
- This new option is enabled by setting `langmuir_opt = 'lf17'` in POP's namelist.


I have tested these change in the following two steps using a JRA55-do forced G-case in CESM (tag cesm2_2_beta04) running for 60 years (looking at mean mixed layer depth of the last 30 years). Here the control run is using default values for the namelist. Testing with a longer simulation is underway. 

1. Update the CVMix repository to v0.97b-beta but do not turn on Langmuir induced entrainment  (`langmuir_opt = 'vr12-ma'`)
2. Turn on the Langmuir induced entrainment (`langmuir_opt = 'lf17'`)

The first step is not bit-for-bit, as described in [this PR](https://github.com/CVMix/CVMix-src/pull/74). But it gives essentially the same mean climate, with small changes in some coastal regions where the boundary layer is very shallow. See the figure below. It's likely due to changes in the order of some operations in CVMix introduced in v0.94b-beta. Note that the panels below plot the summer/winter mean mixed layer depth in both hemispheres together, as in [Li and Fox-Kemper (2017)](https://doi.org/10.1175/JPO-D-17-0085.1).
![20200515_Entrainment_CESM2p2 001](https://user-images.githubusercontent.com/12438579/82067374-e08b4480-968d-11ea-9c62-d646bf640bf8.jpeg)
 
The second step is climate changing, making the mixed layer deeper in the extratropical regions, as expected in [Li and Fox-Kemper (2017)](https://doi.org/10.1175/JPO-D-17-0085.1). Note the different scale in the color bar of the percentage changes.
![20200515_Entrainment_CESM2p2 002](https://user-images.githubusercontent.com/12438579/82067650-3d86fa80-968e-11ea-8239-80f8c3a64286.jpeg)
