### PR TITLE
Update ecosys forcing

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -1692,7 +1692,8 @@ if ($ecosys_on eq "TRUE") {
   add_default($nl, 'iron_frac_in_atm_fine_dust');
   add_default($nl, 'iron_frac_in_atm_coarse_dust');
   add_default($nl, 'iron_frac_in_seaice_dust');
-  add_default($nl, 'iron_frac_in_atm_bc');
+  add_default($nl, 'atm_bc_fe_bioavail_frac');
+  add_default($nl, 'atm_fe_to_bc_ratio');
   add_default($nl, 'iron_frac_in_seaice_bc');
 }
 

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -1694,7 +1694,8 @@ if ($ecosys_on eq "TRUE") {
   add_default($nl, 'iron_frac_in_seaice_dust');
   add_default($nl, 'atm_bc_fe_bioavail_frac');
   add_default($nl, 'atm_fe_to_bc_ratio');
-  add_default($nl, 'iron_frac_in_seaice_bc');
+  add_default($nl, 'seaice_bc_fe_bioavail_frac');
+  add_default($nl, 'seaice_fe_to_bc_ratio');
 }
 
 ##########################################

--- a/bld/namelist_files/namelist_defaults_pop.xml
+++ b/bld/namelist_files/namelist_defaults_pop.xml
@@ -1357,25 +1357,13 @@
 <iron_flux_source ocn_coupling="partial" ocn_bgc_config="cesm2.0">monthly-calendar</iron_flux_source>
 
 <dust_ratio_thres>60.0</dust_ratio_thres>
-<dust_ratio_thres ocn_bgc_config="cesm2.1">55.0</dust_ratio_thres>
-<dust_ratio_thres ocn_bgc_config="cesm2.0">60.0</dust_ratio_thres>
 <dust_ratio_thres ocn_coupling="partial">69.00594</dust_ratio_thres>
-<dust_ratio_thres ocn_bgc_config="cesm2.1" ocn_coupling="partial">66.2818</dust_ratio_thres>
-<dust_ratio_thres ocn_bgc_config="cesm2.0" ocn_coupling="partial">60</dust_ratio_thres>
 
 <fe_bioavail_frac_offset>0.01</fe_bioavail_frac_offset>
-<fe_bioavail_frac_offset ocn_bgc_config="cesm2.1">0.01</fe_bioavail_frac_offset>
-<fe_bioavail_frac_offset ocn_bgc_config="cesm2.0">0.01</fe_bioavail_frac_offset>
 <fe_bioavail_frac_offset ocn_coupling="partial">0.0146756</fe_bioavail_frac_offset>
-<fe_bioavail_frac_offset ocn_bgc_config="cesm2.1" ocn_coupling="partial">0.0131875</fe_bioavail_frac_offset>
-<fe_bioavail_frac_offset ocn_bgc_config="cesm2.0" ocn_coupling="partial">0.01</fe_bioavail_frac_offset>
 
 <dust_ratio_to_fe_bioavail_frac_r>170.0</dust_ratio_to_fe_bioavail_frac_r>
-<dust_ratio_to_fe_bioavail_frac_r ocn_bgc_config="cesm2.1">170.0</dust_ratio_to_fe_bioavail_frac_r>
-<dust_ratio_to_fe_bioavail_frac_r ocn_bgc_config="cesm2.0">170.0</dust_ratio_to_fe_bioavail_frac_r>
 <dust_ratio_to_fe_bioavail_frac_r ocn_coupling="partial">366.314</dust_ratio_to_fe_bioavail_frac_r>
-<dust_ratio_to_fe_bioavail_frac_r ocn_bgc_config="cesm2.1" ocn_coupling="partial">400.064</dust_ratio_to_fe_bioavail_frac_r>
-<dust_ratio_to_fe_bioavail_frac_r ocn_bgc_config="cesm2.0" ocn_coupling="partial">170.0</dust_ratio_to_fe_bioavail_frac_r>
 
 <iron_flux_input%filename ocn_grid="gx3v7">ocn/pop/gx3v7/forcing/solFe_scenario4_current_gx3v7_6gmol_cesm1_93_20161122.nc</iron_flux_input%filename>
 <iron_flux_input%filename ocn_grid="gx1v6">ocn/pop/gx1v6/forcing/solFe_scenario4_current_gx1v6_8gmol_cesm1_93_20161114.nc</iron_flux_input%filename>

--- a/bld/namelist_files/namelist_defaults_pop.xml
+++ b/bld/namelist_files/namelist_defaults_pop.xml
@@ -1625,7 +1625,8 @@
 
 <atm_bc_fe_bioavail_frac>0.06</atm_bc_fe_bioavail_frac>
 <atm_fe_to_bc_ratio>1.0</atm_fe_to_bc_ratio>
-<iron_frac_in_seaice_bc>0.06</iron_frac_in_seaice_bc>
+<seaice_bc_fe_bioavail_frac>0.06</seaice_bc_fe_bioavail_frac>
+<seaice_fe_to_bc_ratio>1.0</seaice_fe_to_bc_ratio>
 
 <!----------------------------->
 <!-- ecosys_tracer_init_nml  -->

--- a/bld/namelist_files/namelist_defaults_pop.xml
+++ b/bld/namelist_files/namelist_defaults_pop.xml
@@ -1359,16 +1359,23 @@
 <dust_ratio_thres>60.0</dust_ratio_thres>
 <dust_ratio_thres ocn_bgc_config="cesm2.1">55.0</dust_ratio_thres>
 <dust_ratio_thres ocn_bgc_config="cesm2.0">60.0</dust_ratio_thres>
-<dust_ratio_thres ocn_coupling="partial">66.2818</dust_ratio_thres>
+<dust_ratio_thres ocn_coupling="partial">69.00594</dust_ratio_thres>
+<dust_ratio_thres ocn_bgc_config="cesm2.1" ocn_coupling="partial">66.2818</dust_ratio_thres>
+<dust_ratio_thres ocn_bgc_config="cesm2.0" ocn_coupling="partial">60</dust_ratio_thres>
 
 <fe_bioavail_frac_offset>0.01</fe_bioavail_frac_offset>
 <fe_bioavail_frac_offset ocn_bgc_config="cesm2.1">0.01</fe_bioavail_frac_offset>
 <fe_bioavail_frac_offset ocn_bgc_config="cesm2.0">0.01</fe_bioavail_frac_offset>
-<fe_bioavail_frac_offset ocn_coupling="partial">0.0131875</fe_bioavail_frac_offset>
+<fe_bioavail_frac_offset ocn_coupling="partial">0.0146756</fe_bioavail_frac_offset>
+<fe_bioavail_frac_offset ocn_bgc_config="cesm2.1" ocn_coupling="partial">0.0131875</fe_bioavail_frac_offset>
+<fe_bioavail_frac_offset ocn_bgc_config="cesm2.0" ocn_coupling="partial">0.01</fe_bioavail_frac_offset>
 
 <dust_ratio_to_fe_bioavail_frac_r>170.0</dust_ratio_to_fe_bioavail_frac_r>
+<dust_ratio_to_fe_bioavail_frac_r ocn_bgc_config="cesm2.1">170.0</dust_ratio_to_fe_bioavail_frac_r>
 <dust_ratio_to_fe_bioavail_frac_r ocn_bgc_config="cesm2.0">170.0</dust_ratio_to_fe_bioavail_frac_r>
-<dust_ratio_to_fe_bioavail_frac_r ocn_coupling="partial">400.064</dust_ratio_to_fe_bioavail_frac_r>
+<dust_ratio_to_fe_bioavail_frac_r ocn_coupling="partial">366.314</dust_ratio_to_fe_bioavail_frac_r>
+<dust_ratio_to_fe_bioavail_frac_r ocn_bgc_config="cesm2.1" ocn_coupling="partial">400.064</dust_ratio_to_fe_bioavail_frac_r>
+<dust_ratio_to_fe_bioavail_frac_r ocn_bgc_config="cesm2.0" ocn_coupling="partial">170.0</dust_ratio_to_fe_bioavail_frac_r>
 
 <iron_flux_input%filename ocn_grid="gx3v7">ocn/pop/gx3v7/forcing/solFe_scenario4_current_gx3v7_6gmol_cesm1_93_20161122.nc</iron_flux_input%filename>
 <iron_flux_input%filename ocn_grid="gx1v6">ocn/pop/gx1v6/forcing/solFe_scenario4_current_gx1v6_8gmol_cesm1_93_20161114.nc</iron_flux_input%filename>

--- a/bld/namelist_files/namelist_defaults_pop.xml
+++ b/bld/namelist_files/namelist_defaults_pop.xml
@@ -1356,11 +1356,13 @@
 <iron_flux_source>driver-derived</iron_flux_source>
 <iron_flux_source ocn_coupling="partial" ocn_bgc_config="cesm2.0">monthly-calendar</iron_flux_source>
 
-<dust_ratio_thres>55.0</dust_ratio_thres>
+<dust_ratio_thres>60.0</dust_ratio_thres>
+<dust_ratio_thres ocn_bgc_config="cesm2.1">55.0</dust_ratio_thres>
 <dust_ratio_thres ocn_bgc_config="cesm2.0">60.0</dust_ratio_thres>
 <dust_ratio_thres ocn_coupling="partial">66.2818</dust_ratio_thres>
 
 <fe_bioavail_frac_offset>0.01</fe_bioavail_frac_offset>
+<fe_bioavail_frac_offset ocn_bgc_config="cesm2.1">0.01</fe_bioavail_frac_offset>
 <fe_bioavail_frac_offset ocn_bgc_config="cesm2.0">0.01</fe_bioavail_frac_offset>
 <fe_bioavail_frac_offset ocn_coupling="partial">0.0131875</fe_bioavail_frac_offset>
 

--- a/bld/namelist_files/namelist_defaults_pop.xml
+++ b/bld/namelist_files/namelist_defaults_pop.xml
@@ -1623,7 +1623,8 @@
 <iron_frac_in_atm_coarse_dust>0.035</iron_frac_in_atm_coarse_dust>
 <iron_frac_in_seaice_dust>0.035</iron_frac_in_seaice_dust>
 
-<iron_frac_in_atm_bc>0.06</iron_frac_in_atm_bc>
+<atm_bc_fe_bioavail_frac>0.06</atm_bc_fe_bioavail_frac>
+<atm_fe_to_bc_ratio>1.0</atm_fe_to_bc_ratio>
 <iron_frac_in_seaice_bc>0.06</iron_frac_in_seaice_bc>
 
 <!----------------------------->

--- a/bld/namelist_files/namelist_definition_pop.xml
+++ b/bld/namelist_files/namelist_definition_pop.xml
@@ -7014,14 +7014,25 @@ Default: 0.035
 </entry>
 
 <entry
-id="iron_frac_in_atm_bc"
+id="atm_bc_fe_bioavail_frac"
 type="real"
 category="ecosys"
 category="Forcing (Ecosystem)"
 group="ecosys_forcing_data_nml">
-fraction, by weight, of iron in black carbon from atm
+fraction, by weight, of soluble iron in black carbon from atm
 
 Default: 0.06
+</entry>
+
+<entry
+id="atm_fe_to_bc_ratio"
+type="real"
+category="ecosys"
+category="Forcing (Ecosystem)"
+group="ecosys_forcing_data_nml">
+ratio of iron mass to black carbon mass emitted from combustion
+
+Default: 1.0
 </entry>
 
 <entry

--- a/bld/namelist_files/namelist_definition_pop.xml
+++ b/bld/namelist_files/namelist_definition_pop.xml
@@ -7019,7 +7019,7 @@ type="real"
 category="ecosys"
 category="Forcing (Ecosystem)"
 group="ecosys_forcing_data_nml">
-fraction, by weight, of soluble iron in black carbon from atm
+fraction, by weight, of soluble fe in fe associated with black carbon from atm
 
 Default: 0.06
 </entry>
@@ -7040,7 +7040,7 @@ id="seaice_bc_fe_bioavail_frac"
 type="real"
 category="Forcing (Ecosystem)"
 group="ecosys_forcing_data_nml">
-fraction, by weight, of soluble iron in black carbon from seaice
+fraction, by weight, of soluble fe in fe associated with black carbon from seaice
 
 Default: 0.06
 </entry>

--- a/bld/namelist_files/namelist_definition_pop.xml
+++ b/bld/namelist_files/namelist_definition_pop.xml
@@ -7036,11 +7036,21 @@ Default: 1.0
 </entry>
 
 <entry
-id="iron_frac_in_seaice_bc"
+id="seaice_bc_fe_bioavail_frac"
 type="real"
 category="Forcing (Ecosystem)"
 group="ecosys_forcing_data_nml">
-fraction, by weight, of iron in black carbon from seaice
+fraction, by weight, of soluble iron in black carbon from seaice
+
+Default: 0.06
+</entry>
+
+<entry
+id="seaice_fe_to_bc_ratio"
+type="real"
+category="Forcing (Ecosystem)"
+group="ecosys_forcing_data_nml">
+ratio of iron mass to black carbon mass emitted from seaice
 
 Default: 0.06
 </entry>

--- a/source/ecosys_forcing_mod.F90
+++ b/source/ecosys_forcing_mod.F90
@@ -301,7 +301,8 @@ module ecosys_forcing_mod
   real(r8) :: iron_frac_in_seaice_dust
   real(r8) :: atm_bc_fe_bioavail_frac
   real(r8) :: atm_fe_to_bc_ratio
-  real(r8) :: iron_frac_in_seaice_bc
+  real(r8) :: seaice_bc_fe_bioavail_frac
+  real(r8) :: seaice_fe_to_bc_ratio
 
   real(r8) :: d14c_glo_avg       ! global average D14C over the ocean, computed from current D14C field
 
@@ -418,7 +419,7 @@ contains
          surf_avg_di13c_const, surf_avg_di14c_const,                          &
          iron_frac_in_atm_fine_dust, iron_frac_in_atm_coarse_dust,            &
          iron_frac_in_seaice_dust, atm_bc_fe_bioavail_frac, atm_fe_to_bc_ratio, &
-         iron_frac_in_seaice_bc
+         seaice_bc_fe_bioavail_frac, seaice_fe_to_bc_ratio
 
     !-----------------------------------------------------------------------
     !  &ecosys_forcing_data_nml
@@ -516,7 +517,8 @@ contains
     iron_frac_in_seaice_dust     = 0.035_r8
     atm_bc_fe_bioavail_frac      = 0.06_r8
     atm_fe_to_bc_ratio           = 1.0_r8
-    iron_frac_in_seaice_bc       = 0.06_r8
+    seaice_bc_fe_bioavail_frac   = 0.06_r8
+    seaice_fe_to_bc_ratio        = 1.0_r8
 
     read(forcing_nml, nml=ecosys_forcing_data_nml, iostat=nml_error, iomsg=ioerror_msg)
     if (nml_error /= 0) then
@@ -1992,8 +1994,8 @@ contains
                    seaice_fe_bioavail_frac(:,:) = atm_fe_bioavail_frac(:,:)
 
                    forcing_field%field_0d(:,:,iblock) = forcing_field%field_0d(:,:,iblock) + seaice_fe_bioavail_frac(:,:) * &
-                        (iron_frac_in_seaice_dust * seaice_dust_flux(:,:,iblock) + &
-                         iron_frac_in_seaice_bc * seaice_black_carbon_flux(:,:,iblock))
+                        (iron_frac_in_seaice_dust * seaice_dust_flux(:,:,iblock)) + &
+                        seaice_bc_fe_bioavail_frac * seaice_fe_to_bc_ratio * seaice_black_carbon_flux(:,:,iblock)
 
                    ! convert to nmol/cm^2/s
                    forcing_field%field_0d(:,:,iblock) = (1.0e9_r8 / molw_Fe) * forcing_field%field_0d(:,:,iblock)

--- a/source/ecosys_forcing_mod.F90
+++ b/source/ecosys_forcing_mod.F90
@@ -509,7 +509,7 @@ contains
 
     dust_flux_source             = 'driver'
     iron_flux_source             = 'driver-derived'
-    dust_ratio_thres             = 55.0_r8
+    dust_ratio_thres             = 60.0_r8
     fe_bioavail_frac_offset      = 0.01_r8
     dust_ratio_to_fe_bioavail_frac_r = 170.0_r8
     iron_frac_in_atm_fine_dust   = 0.035_r8

--- a/source/ecosys_forcing_mod.F90
+++ b/source/ecosys_forcing_mod.F90
@@ -299,7 +299,8 @@ module ecosys_forcing_mod
   real(r8) :: iron_frac_in_atm_fine_dust
   real(r8) :: iron_frac_in_atm_coarse_dust
   real(r8) :: iron_frac_in_seaice_dust
-  real(r8) :: iron_frac_in_atm_bc
+  real(r8) :: atm_bc_fe_bioavail_frac
+  real(r8) :: atm_fe_to_bc_ratio
   real(r8) :: iron_frac_in_seaice_bc
 
   real(r8) :: d14c_glo_avg       ! global average D14C over the ocean, computed from current D14C field
@@ -416,7 +417,8 @@ contains
          surf_avg_alk_const, surf_avg_dic_const,                              &
          surf_avg_di13c_const, surf_avg_di14c_const,                          &
          iron_frac_in_atm_fine_dust, iron_frac_in_atm_coarse_dust,            &
-         iron_frac_in_seaice_dust, iron_frac_in_atm_bc, iron_frac_in_seaice_bc
+         iron_frac_in_seaice_dust, atm_bc_fe_bioavail_frac, atm_fe_to_bc_ratio, &
+         iron_frac_in_seaice_bc
 
     !-----------------------------------------------------------------------
     !  &ecosys_forcing_data_nml
@@ -427,12 +429,7 @@ contains
     call set_defaults_tracer_read(gas_flux_fice, file_varname='FICE')
     call set_defaults_tracer_read(gas_flux_ws, file_varname='XKW')
     call set_defaults_tracer_read(gas_flux_ap, file_varname='P')
-    dust_flux_source             = 'driver'
     call set_defaults_tracer_read(dust_flux_input, file_varname='dust_flux')
-    iron_flux_source             = 'driver-derived'
-    dust_ratio_thres             = 55.0_r8
-    fe_bioavail_frac_offset      = 0.01_r8
-    dust_ratio_to_fe_bioavail_frac_r = 170.0_r8
     call set_defaults_tracer_read(iron_flux_input, file_varname='iron_flux')
     call set_defaults_tracer_read(fesedflux_input, file_varname='FESEDFLUXIN')
     call set_defaults_tracer_read(feventflux_input, file_varname='FESEDFLUXIN')
@@ -509,10 +506,16 @@ contains
     surf_avg_di13c_const     = 1944.0_r8
     surf_avg_di14c_const     = 1944.0_r8
 
+    dust_flux_source             = 'driver'
+    iron_flux_source             = 'driver-derived'
+    dust_ratio_thres             = 55.0_r8
+    fe_bioavail_frac_offset      = 0.01_r8
+    dust_ratio_to_fe_bioavail_frac_r = 170.0_r8
     iron_frac_in_atm_fine_dust   = 0.035_r8
     iron_frac_in_atm_coarse_dust = 0.035_r8
     iron_frac_in_seaice_dust     = 0.035_r8
-    iron_frac_in_atm_bc          = 0.06_r8
+    atm_bc_fe_bioavail_frac      = 0.06_r8
+    atm_fe_to_bc_ratio           = 1.0_r8
     iron_frac_in_seaice_bc       = 0.06_r8
 
     read(forcing_nml, nml=ecosys_forcing_data_nml, iostat=nml_error, iomsg=ioerror_msg)
@@ -1981,8 +1984,8 @@ contains
 
                    forcing_field%field_0d(:,:,iblock) = atm_fe_bioavail_frac(:,:) * &
                         (iron_frac_in_atm_fine_dust * atm_fine_dust_flux(:,:,iblock) + &
-                         iron_frac_in_atm_coarse_dust * atm_coarse_dust_flux(:,:,iblock) + &
-                         iron_frac_in_atm_bc * atm_black_carbon_flux(:,:,iblock))
+                         iron_frac_in_atm_coarse_dust * atm_coarse_dust_flux(:,:,iblock)) + &
+                        atm_bc_fe_bioavail_frac  * atm_fe_to_bc_ratio * atm_black_carbon_flux(:,:,iblock)
 
                    ! add component from seaice
 


### PR DESCRIPTION
### Description of changes:

Added two extra namelist variables to `ecosys_forcing_mod.F90` and gave two other existing variables clearer names to improve iron flux computation.

### Testing:
 
Test case/suite: `aux_pop` and `aux_pop_MARBL` (also built / ran a case on `hobart_nag`)
Test status: Definitely answer changing -- I presume not climate-changing

Fixes #17 

User interface (namelist or namelist defaults) changes? `iron_frac_in_atm_bc` and `iron_frac_in_seaice_bc` are no longer in the namelist, while `atm_bc_fe_bioavail_frac`, `atm_fe_to_bc_ratio`, `seaice_bc_fe_bioavail_frac`, and `seaice_fe_to_bc_ratio` are

