### PR TITLE
Bgc updates for cesm2 2

### DIFF
--- a/Externals_POP.cfg
+++ b/Externals_POP.cfg
@@ -6,7 +6,7 @@ local_path = externals/CVMix
 required = True
 
 [MARBL]
-tag = marbl0.35.0
+tag = marbl0.39.0
 protocol = git
 repo_url = https://github.com/marbl-ecosys/MARBL
 local_path = externals/MARBL

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -344,6 +344,7 @@ my $OCN_TRACER_MODULES_OPT = "$xmlvars{'OCN_TRACER_MODULES_OPT'}";
 my $OCN_TAVG_TRACER_BUDGET = "$xmlvars{'OCN_TAVG_TRACER_BUDGET'}";
 my $OCN_TAVG_HIFREQ        = "$xmlvars{'OCN_TAVG_HIFREQ'}";
 my $OCN_ONEDIM             = "$xmlvars{'OCN_ONEDIM'}";
+my $OCN_PHYS_DEV           = "$xmlvars{'OCN_PHYS_DEV'}";
 my $POP_DECOMPTYPE         = "$xmlvars{'POP_DECOMPTYPE'}";
 my $INFO_DBUG              = "$xmlvars{'INFO_DBUG'}";
 my $RUN_TYPE               = "$xmlvars{'RUN_TYPE'}";
@@ -920,7 +921,7 @@ add_default($nl, 'ah&hmix_del4t_nml');
 add_default($nl, 'kappa_isop_choice');
 add_default($nl, 'kappa_thic_choice');
 
-add_default($nl, 'kappa_isop_deep');
+add_default($nl, 'kappa_isop_deep','ocn_phys_dev'=>"$OCN_PHYS_DEV");
 add_default($nl, 'kappa_thic_deep');
 
 # All namelist values are stored in exactly the format

--- a/bld/namelist_files/namelist_defaults_pop.xml
+++ b/bld/namelist_files/namelist_defaults_pop.xml
@@ -1634,10 +1634,12 @@
 <!----------------------------->
 
 <init_ecosys_init_file ocn_grid="gx3v7">ocn/pop/gx3v7/ic/ecosys_jan_IC_gx3v7_20180308.nc</init_ecosys_init_file>
+<init_ecosys_init_file ocn_grid="gx3v7" ocn_bgc_config="with_cocco">ocn/pop/gx3v7/ic/ecosys_jan_IC_gx3v7_20200325.nc</init_ecosys_init_file>
 <init_ecosys_init_file ocn_grid="gx3v7" ocn_bgc_config="cesm2.1+cocco">ocn/pop/gx3v7/ic/ecosys_jan_IC_gx3v7_20200325.nc</init_ecosys_init_file>
 <init_ecosys_init_file ocn_grid="gx3v7" ocn_bgc_config="SPECTRA1.0">ocn/pop/gx3v7/ic/ecosys_jan_IC_gx3v7_9p6z_20200325_3impCalc.nc</init_ecosys_init_file>
 
 <init_ecosys_init_file ocn_grid="gx1v6">ocn/pop/gx1v6/ic/ecosys_jan_IC_gx1v6_20180308.nc</init_ecosys_init_file>
+<init_ecosys_init_file ocn_grid="gx1v6" ocn_bgc_config="with_cocco">ocn/pop/gx1v6/ic/ecosys_jan_IC_gx1v6_20200325.nc</init_ecosys_init_file>
 <init_ecosys_init_file ocn_grid="gx1v6" ocn_bgc_config="cesm2.1+cocco">ocn/pop/gx1v6/ic/ecosys_jan_IC_gx1v6_20200325.nc</init_ecosys_init_file>
 <init_ecosys_init_file ocn_grid="gx1v6" ocn_bgc_config="SPECTRA1.0">ocn/pop/gx1v6/ic/ecosys_jan_IC_gx1v6_9p6z_20200325_3impCalc.nc</init_ecosys_init_file>
 

--- a/bld/namelist_files/namelist_defaults_pop.xml
+++ b/bld/namelist_files/namelist_defaults_pop.xml
@@ -1378,7 +1378,11 @@
 
 <fesedflux_input%filename ocn_grid="gx3v7">ocn/pop/gx3v7/forcing/fesedflux_gx3v7_cesm1_97_2017.nc</fesedflux_input%filename>
 <fesedflux_input%filename ocn_grid="gx1v6">ocn/pop/gx1v6/forcing/fesedfluxTot_gx1v6_cesm2_2018_c180618.nc</fesedflux_input%filename>
-<fesedflux_input%filename ocn_grid="gx1v7">ocn/pop/gx1v6/forcing/fesedfluxTot_gx1v6_cesm2_2018_c180618.nc</fesedflux_input%filename>
+<fesedflux_input%filename ocn_grid="gx1v7">ocn/pop/gx1v6/forcing/fesedflux_total_reduce_oxic_POP_gx1v7.c200618.nc</fesedflux_input%filename>
+<fesedflux_input%filename ocn_grid="gx1v6" ocn_bgc_config="cesm2.1">ocn/pop/gx1v6/forcing/fesedfluxTot_gx1v6_cesm2_2018_c180618.nc</fesedflux_input%filename>
+<fesedflux_input%filename ocn_grid="gx1v7" ocn_bgc_config="cesm2.1">ocn/pop/gx1v6/forcing/fesedfluxTot_gx1v6_cesm2_2018_c180618.nc</fesedflux_input%filename>
+<fesedflux_input%filename ocn_grid="gx1v6" ocn_bgc_config="cesm2.1+cocco">ocn/pop/gx1v6/forcing/fesedfluxTot_gx1v6_cesm2_2018_c180618.nc</fesedflux_input%filename>
+<fesedflux_input%filename ocn_grid="gx1v7" ocn_bgc_config="cesm2.1+cocco">ocn/pop/gx1v6/forcing/fesedfluxTot_gx1v6_cesm2_2018_c180618.nc</fesedflux_input%filename>
 <fesedflux_input%filename ocn_grid="gx1v6" ocn_bgc_config="cesm2.0">ocn/pop/gx1v6/forcing/fesedflux_gx1v6_cesm2_2017.nc</fesedflux_input%filename>
 <fesedflux_input%filename ocn_grid="gx1v7" ocn_bgc_config="cesm2.0">ocn/pop/gx1v6/forcing/fesedflux_gx1v6_cesm2_2017.nc</fesedflux_input%filename>
 
@@ -1638,8 +1642,10 @@
 <init_ecosys_init_file ocn_grid="gx1v6" ocn_bgc_config="SPECTRA1.0">ocn/pop/gx1v6/ic/ecosys_jan_IC_gx1v6_9p6z_20200325_3impCalc.nc</init_ecosys_init_file>
 
 <init_ecosys_init_file ocn_grid="gx1v7">ocn/pop/gx1v6/ic/ecosys_jan_IC_omip_POP_gx1v7_c200323.nc</init_ecosys_init_file>
-<init_ecosys_init_file ocn_grid="gx1v7" ocn_bgc_config="cesm2.0">ocn/pop/gx1v6/ic/ecosys_jan_IC_gx1v6_20180308.nc</init_ecosys_init_file>
+<init_ecosys_init_file ocn_grid="gx1v7" ocn_bgc_config="with_cocco">ocn/pop/gx1v6/ic/ecosys_jan_IC_omip_POP_gx1v7_c200617.nc</init_ecosys_init_file>
+<init_ecosys_init_file ocn_grid="gx1v7" ocn_bgc_config="cesm2.1">ocn/pop/gx1v6/ic/ecosys_jan_IC_omip_POP_gx1v7_c200323.nc</init_ecosys_init_file>
 <init_ecosys_init_file ocn_grid="gx1v7" ocn_bgc_config="cesm2.1+cocco">ocn/pop/gx1v6/ic/ecosys_jan_IC_gx1v6_20200325.nc</init_ecosys_init_file>
+<init_ecosys_init_file ocn_grid="gx1v7" ocn_bgc_config="cesm2.0">ocn/pop/gx1v6/ic/ecosys_jan_IC_gx1v6_20180308.nc</init_ecosys_init_file>
 <init_ecosys_init_file ocn_grid="gx1v7" ocn_bgc_config="SPECTRA1.0">ocn/pop/gx1v6/ic/ecosys_jan_IC_gx1v6_9p6z_20200325_3impCalc.nc</init_ecosys_init_file>
 
 <init_ecosys_init_file_fmt>nc</init_ecosys_init_file_fmt>

--- a/bld/namelist_files/namelist_defaults_pop.xml
+++ b/bld/namelist_files/namelist_defaults_pop.xml
@@ -596,10 +596,10 @@
 <!-- enhanced diffusivity at depth, only default for 1 degree -->
 <!-- until validated at other resolutions                     -->
 <!-------------------------------------------------------------->
-<kappa_thic_deep                               >0.1</kappa_thic_deep>
-<kappa_isop_deep                               >0.1</kappa_isop_deep>
-<kappa_isop_deep  ocn_grid="gx1v6"             >0.2</kappa_isop_deep>
-<kappa_isop_deep  ocn_grid="gx1v7"             >0.2</kappa_isop_deep>
+<kappa_thic_deep>0.1</kappa_thic_deep>
+<kappa_isop_deep>0.1</kappa_isop_deep>
+<kappa_isop_deep ocn_grid="gx1v6" ocn_phys_dev="FALSE">0.2</kappa_isop_deep>
+<kappa_isop_deep ocn_grid="gx1v7" ocn_phys_dev="FALSE">0.2</kappa_isop_deep>
 
 <!---------------------------->
 <!-- hmix_gm_nml -->

--- a/bld/namelist_files/namelist_defaults_pop.xml
+++ b/bld/namelist_files/namelist_defaults_pop.xml
@@ -1640,17 +1640,17 @@
 <!----------------------------->
 
 <init_ecosys_init_file ocn_grid="gx3v7">ocn/pop/gx3v7/ic/ecosys_jan_IC_gx3v7_20180308.nc</init_ecosys_init_file>
-<init_ecosys_init_file ocn_grid="gx3v7" ocn_bgc_config="with_cocco">ocn/pop/gx3v7/ic/ecosys_jan_IC_gx3v7_20200325.nc</init_ecosys_init_file>
+<init_ecosys_init_file ocn_grid="gx3v7" ocn_bgc_config="latest+cocco">ocn/pop/gx3v7/ic/ecosys_jan_IC_gx3v7_20200325.nc</init_ecosys_init_file>
 <init_ecosys_init_file ocn_grid="gx3v7" ocn_bgc_config="cesm2.1+cocco">ocn/pop/gx3v7/ic/ecosys_jan_IC_gx3v7_20200325.nc</init_ecosys_init_file>
 <init_ecosys_init_file ocn_grid="gx3v7" ocn_bgc_config="SPECTRA1.0">ocn/pop/gx3v7/ic/ecosys_jan_IC_gx3v7_9p6z_20200325_3impCalc.nc</init_ecosys_init_file>
 
 <init_ecosys_init_file ocn_grid="gx1v6">ocn/pop/gx1v6/ic/ecosys_jan_IC_gx1v6_20180308.nc</init_ecosys_init_file>
-<init_ecosys_init_file ocn_grid="gx1v6" ocn_bgc_config="with_cocco">ocn/pop/gx1v6/ic/ecosys_jan_IC_gx1v6_20200325.nc</init_ecosys_init_file>
+<init_ecosys_init_file ocn_grid="gx1v6" ocn_bgc_config="latest+cocco">ocn/pop/gx1v6/ic/ecosys_jan_IC_gx1v6_20200325.nc</init_ecosys_init_file>
 <init_ecosys_init_file ocn_grid="gx1v6" ocn_bgc_config="cesm2.1+cocco">ocn/pop/gx1v6/ic/ecosys_jan_IC_gx1v6_20200325.nc</init_ecosys_init_file>
 <init_ecosys_init_file ocn_grid="gx1v6" ocn_bgc_config="SPECTRA1.0">ocn/pop/gx1v6/ic/ecosys_jan_IC_gx1v6_9p6z_20200325_3impCalc.nc</init_ecosys_init_file>
 
 <init_ecosys_init_file ocn_grid="gx1v7">ocn/pop/gx1v6/ic/ecosys_jan_IC_omip_POP_gx1v7_c200323.nc</init_ecosys_init_file>
-<init_ecosys_init_file ocn_grid="gx1v7" ocn_bgc_config="with_cocco">ocn/pop/gx1v6/ic/ecosys_jan_IC_omip_POP_gx1v7_c200617.nc</init_ecosys_init_file>
+<init_ecosys_init_file ocn_grid="gx1v7" ocn_bgc_config="latest+cocco">ocn/pop/gx1v6/ic/ecosys_jan_IC_omip_POP_gx1v7_c200617.nc</init_ecosys_init_file>
 <init_ecosys_init_file ocn_grid="gx1v7" ocn_bgc_config="cesm2.1">ocn/pop/gx1v6/ic/ecosys_jan_IC_omip_POP_gx1v7_c200323.nc</init_ecosys_init_file>
 <init_ecosys_init_file ocn_grid="gx1v7" ocn_bgc_config="cesm2.1+cocco">ocn/pop/gx1v6/ic/ecosys_jan_IC_gx1v6_20200325.nc</init_ecosys_init_file>
 <init_ecosys_init_file ocn_grid="gx1v7" ocn_bgc_config="cesm2.0">ocn/pop/gx1v6/ic/ecosys_jan_IC_gx1v6_20180308.nc</init_ecosys_init_file>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -218,7 +218,7 @@
 
   <entry id="OCN_BGC_CONFIG">
     <type>char</type>
-    <valid_values>latest,with_cocco,cesm2.1,cesm2.1+cocco,cesm2.0,SPECTRA1.0</valid_values>
+    <valid_values>latest,latest+cocco,cesm2.1,cesm2.1+cocco,cesm2.0,SPECTRA1.0</valid_values>
     <default_value>latest</default_value>
     <values>
 	<value compset="POP2%[^_]*ECOCESM21">cesm2.1</value>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -203,7 +203,7 @@
 
   <entry id="OCN_BGC_CONFIG">
     <type>char</type>
-    <valid_values>latest,cesm2.0,SPECTRA1.0,cesm2.1+cocco</valid_values>
+    <valid_values>latest,with_cocco,cesm2.1,cesm2.1+cocco,cesm2.0,SPECTRA1.0</valid_values>
     <default_value>latest</default_value>
     <values>
 	<value compset="POP2%[^_]*ECOCESM20">cesm2.0</value>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -2,9 +2,10 @@
 
 <entry_id version="3.0">
   <description modifier_mode="*">
-    <desc ocn="POP2[%1D][%ECO][%ECOCESM20][%ABIO-DIC][%PHYS-CYCLE][%DAR][%NDEP]">POP2 </desc>
+    <desc ocn="POP2[%1D][%ECO][%ECOCESM21][%ECOCESM20][%ABIO-DIC][%PHYS-CYCLE][%DAR][%NDEP]">POP2 </desc>
     <desc option="1D" >Single column </desc>
     <desc option="ECO">Ecosystem</desc>
+    <desc option="ECOCESM21">Ecosystem, using CESM 2.1 settings</desc>
     <desc option="ECOCESM20">Ecosystem, using CESM 2.0 settings</desc>
     <desc option="ABIO-DIC">Abiotic DIC/DIC14</desc>
     <desc option="PHYS-CYCLE">phys cycle option</desc>
@@ -206,6 +207,7 @@
     <valid_values>latest,with_cocco,cesm2.1,cesm2.1+cocco,cesm2.0,SPECTRA1.0</valid_values>
     <default_value>latest</default_value>
     <values>
+	<value compset="POP2%[^_]*ECOCESM21">cesm2.1</value>
 	<value compset="POP2%[^_]*ECOCESM20">cesm2.0</value>
     </values>
     <group>run_component_pop</group>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -2,8 +2,9 @@
 
 <entry_id version="3.0">
   <description modifier_mode="*">
-    <desc ocn="POP2[%1D][%ECO][%ECOCESM21][%ECOCESM20][%ABIO-DIC][%PHYS-CYCLE][%DAR][%NDEP]">POP2 </desc>
+    <desc ocn="POP2[%1D][%PHYS-DEV][%ECO][%ECOCESM21][%ECOCESM20][%ABIO-DIC][%PHYS-CYCLE][%DAR][%NDEP]">POP2 </desc>
     <desc option="1D" >Single column </desc>
+    <desc option="PHYS-DEV">Use development namelist defaults</desc>
     <desc option="ECO">Ecosystem</desc>
     <desc option="ECOCESM21">Ecosystem, using CESM 2.1 settings</desc>
     <desc option="ECOCESM20">Ecosystem, using CESM 2.0 settings</desc>
@@ -80,6 +81,19 @@
     <group>run_component_pop</group>
     <file>env_run.xml</file>
     <desc>TRUE turns off all horizontal motion in POP (single column)</desc>
+  </entry>
+
+  <entry id="OCN_PHYS_DEV">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <values>
+      <value compset = "_POP2%[^_]*PHYS-DEV">TRUE</value>
+    </values>
+    <group>run_component_pop</group>
+    <file>env_run.xml</file>
+    <desc>TRUE uses development parameter settings that haven't necessarily
+          been scientifically vetted for all compsets in the POP namelist</desc>
   </entry>
 
   <entry id="OCN_NDEP_DRIVER">

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -82,6 +82,11 @@
   </compset>
 
   <compset>
+    <alias>C1850ECO_ECOCESM21</alias>
+    <lname>1850_DATM%NYF_SLND_DICE%SSMI_POP2%ECOCESM21_DROF%NYF_SGLC_WW3</lname>
+  </compset>
+
+  <compset>
     <alias>C1850ECO_ECOCESM20</alias>
     <lname>1850_DATM%NYF_SLND_DICE%SSMI_POP2%ECOCESM20_DROF%NYF_SGLC_WW3</lname>
   </compset>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -148,9 +148,9 @@
   </compset>
 
   <compset>
-    <!-- latest JRA forcing -->
-    <alias>G1850ECOIAF_JRA</alias>
-    <lname>1850_DATM%JRA-1p4-2018_SLND_CICE_POP2%ECO_DROF%JRA-1p4-2018_SGLC_WW3</lname>
+    <!-- latest JRA forcing with OCN_PHYS_DEV=TRUE -->
+    <alias>G1850ECOIAF_JRA_PHYS_DEV</alias>
+    <lname>1850_DATM%JRA-1p4-2018_SLND_CICE_POP2%ECO%PHYS-DEV_DROF%JRA-1p4-2018_SGLC_WW3</lname>
   </compset>
 
   <compset>

--- a/cime_config/testdefs/testlist_pop.xml
+++ b/cime_config/testdefs/testlist_pop.xml
@@ -474,6 +474,18 @@
       <machine name="hobart" compiler="nag" category="aux_pop_MARBL"/>
     </machines>
   </test>
+  <test name="SMS" grid="T62_g37" compset="C1850ECO_ECOCESM21" testmods="pop/ecosys">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="hobart" compiler="nag" category="aux_pop_MARBL"/>
+    </machines>
+  </test>
+  <test name="SMS" grid="T62_g17" compset="C1850ECO_ECOCESM21" testmods="pop/ecosys">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+    </machines>
+  </test>
   <test name="SMS" grid="T62_g37" compset="C1850ECO_ECOCESM20" testmods="pop/ecosys">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>

--- a/cime_config/testdefs/testlist_pop.xml
+++ b/cime_config/testdefs/testlist_pop.xml
@@ -453,6 +453,12 @@
       <machine name="cheyenne" compiler="intel" category="aux_cime_baselines"/>
     </machines>
   </test>
+  <test name="SMS" grid="T62_g37" compset="C1850ECO_ECOCESM21" testmods="pop/ecosys_add_cocco">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="hobart" compiler="nag" category="aux_pop_MARBL"/>
+    </machines>
+  </test>
   <test name="SMS" grid="T62_g17" compset="C1850ECO" testmods="pop/ecosys_add_cocco">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>

--- a/cime_config/testdefs/testlist_pop.xml
+++ b/cime_config/testdefs/testlist_pop.xml
@@ -537,7 +537,7 @@
       <machine name="cheyenne" compiler="intel" category="aux_cime_baselines"/>
     </machines>
   </test>
-  <test name="SMS_D_Ld2" grid="TL319_g17" compset="G1850ECOIAF_JRA" testmods="pop/cice_ecosys">
+  <test name="SMS_D_Ld2" grid="TL319_g17" compset="G1850ECOIAF_JRA_PHYS_DEV" testmods="pop/cice_ecosys">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
       <machine name="cheyenne" compiler="intel" category="aux_pop"/>

--- a/cime_config/testdefs/testmods_dirs/pop/ecosys_add_cocco/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/pop/ecosys_add_cocco/shell_commands
@@ -1,1 +1,8 @@
-./xmlchange OCN_BGC_CONFIG=cesm2.1+cocco
+# Check current value of OCN_BGC_CONFIG
+ocn_bgc_config=(`./xmlquery OCN_BGC_CONFIG --value`)
+
+if [[ "${ocn_bgc_config}" == "latest" ]]; then
+  ./xmlchange OCN_BGC_CONFIG=with_cocco
+elif [[ "${ocn_bgc_config}" == "cesm2.1" ]]; then
+  ./xmlchange OCN_BGC_CONFIG=cesm2.1+cocco
+fi

--- a/cime_config/testdefs/testmods_dirs/pop/ecosys_add_cocco/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/pop/ecosys_add_cocco/shell_commands
@@ -5,4 +5,7 @@ if [[ "${ocn_bgc_config}" == "latest" ]]; then
   ./xmlchange OCN_BGC_CONFIG=with_cocco
 elif [[ "${ocn_bgc_config}" == "cesm2.1" ]]; then
   ./xmlchange OCN_BGC_CONFIG=cesm2.1+cocco
+elif [[ "${ocn_bgc_config}" != *"cocco"* ]]; then
+  echo "ERROR: OCN_BGC_CONFIG=${ocn_bgc_config} does not have equivalent option with coccolithophores"
+  exit 1
 fi

--- a/cime_config/testdefs/testmods_dirs/pop/ecosys_add_cocco/shell_commands
+++ b/cime_config/testdefs/testmods_dirs/pop/ecosys_add_cocco/shell_commands
@@ -2,7 +2,7 @@
 ocn_bgc_config=(`./xmlquery OCN_BGC_CONFIG --value`)
 
 if [[ "${ocn_bgc_config}" == "latest" ]]; then
-  ./xmlchange OCN_BGC_CONFIG=with_cocco
+  ./xmlchange OCN_BGC_CONFIG=latest+cocco
 elif [[ "${ocn_bgc_config}" == "cesm2.1" ]]; then
   ./xmlchange OCN_BGC_CONFIG=cesm2.1+cocco
 elif [[ "${ocn_bgc_config}" != *"cocco"* ]]; then


### PR DESCRIPTION
### Description of changes:

This branch will update BGC configurations for the CESM2.2 release

1. `OCN_BGC_CONFIG=with_cocco` will use latest tunings with coccolithophores
1. `OCN_BGC_CONFIG=cesm2.1` will use same MARBL parameters as CESM 2.1 (though some bugfixes in POP will prevent bit-for-bit solutions when compared to CESM 2.1)
1. Provide a newly-created `init_ecosys_init_file` for `OCN_BGC_CONFIG=with_cocco`
1. Update `fesedflux_input%filename`
1. Update version of MARBL being used to latest available ([marbl0.39.0](https://github.com/marbl-ecosys/MARBL/releases/tag/marbl0.39.0))
1. Update `ecosys_add_cocco` to use latest tunings
1. Add `POP2%CESM21` compset option similar to `POP2%CESM20` (but to get `OCN_BGC_CONFIG=cesm2.1`)

   * Create `C1850ECO_ECOCESM21` compset and test it in `aux_pop_MARBL`

### Testing:
 
Test case/suite: `aux_pop` on cheyenne (`intel` only), and `aux_pop_MARBL` on cheyenne (`intel` & `gnu`) and hobart (`nag` and `pgi`). `cheyenne` tests were compared against [cesm_pop_2_1_20200709](https://github.com/ESCOMP/POP2-CESM/releases/tag/cesm_pop_2_1_20200709), `hobart` tests did not include baseline comparison
Test status: compsets with ecosystem enabled were answer-changing (even `ECOCESM20` changes answers due to round-off level changes in MARBL) and failed `NLCOMP` (again due to clean-up on the MARBL side); compsets without the ecosystem are bit-for-bit and pass `NLCOMP`

Fixes #32 

User interface (namelist or namelist defaults) changes? None

