### PR TITLE
add Newton-Krylov solver related tavg vars to abio_dic_dic14

### DIFF
--- a/BranchChangeLog
+++ b/BranchChangeLog
@@ -1,3 +1,31 @@
+===============================================================
+Tag Creator: klindsay
+Developers:  klindsay
+Tag Date:    21 Jun 2020
+Tag Name:    pop2/trunk_tags/cesm_pop_2_1_20190306
+Tag Name:    pop2_cesm2_1_rel_n11
+Tag Summary: add Newton-Krylov related tavg vars to abio_dic_dic14
+
+Testing: passes aux_pop on cheyenne/intel, compared to pop2_cesm2_1_rel_n10
+    expected NLCOMP & BASELINE failures for new test
+    some MEMCOMP failures
+
+computation and inclusion of vars in tavg file controlled with nml var abio_dic_dic14_ltavg_NK
+
+nml var enabled in new test ERS_Ld5_D.T62_g37.C.cheyenne_intel.pop-abio_dic_dic14_ltavg_NK
+
+mv io_read_fallback_register_field call for 'ABIO_PH_SURF' outside of all_fields_exist_in_restfile conditional
+
+Changes to be committed:
+	modified:   bld/build-namelist
+	modified:   bld/namelist_files/namelist_defaults_pop.xml
+	modified:   bld/namelist_files/namelist_definition_pop.xml
+	modified:   cime_config/testdefs/testlist_pop.xml
+	new file:   cime_config/testdefs/testmods_dirs/pop/abio_dic_dic14_ltavg_NK/include_user_mods
+	new file:   cime_config/testdefs/testmods_dirs/pop/abio_dic_dic14_ltavg_NK/user_nl_pop
+	modified:   input_templates/ocn.abio_dic_dic14.tavg.csh
+	modified:   source/abio_dic_dic14_mod.F90
+
 ===============================================================================
 Tag Creator:  mlevy
 Developers:   mlevy

--- a/BranchChangeLog
+++ b/BranchChangeLog
@@ -2,7 +2,6 @@
 Tag Creator: klindsay
 Developers:  klindsay
 Tag Date:    21 Jun 2020
-Tag Name:    pop2/trunk_tags/cesm_pop_2_1_20190306
 Tag Name:    pop2_cesm2_1_rel_n11
 Tag Summary: add Newton-Krylov related tavg vars to abio_dic_dic14
 

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -2751,6 +2751,9 @@ sub module_tavg_script_args() {
   my $nl         = shift;
   my $module     = shift;
   my $cfg        = shift;
+  if ($module eq "abio_dic_dic14") {
+    return ($nl->get_value('abio_dic_dic14_ltavg_NK'));
+  }
   if ($module eq "ecosys") {
     return ($nl->get_value('lecosys_tavg_all'),
             $nl->get_value('lecosys_tavg_alt_co2'));

--- a/bld/namelist_files/namelist_defaults_pop.xml
+++ b/bld/namelist_files/namelist_defaults_pop.xml
@@ -1333,6 +1333,12 @@
 <abio_atm_model_year>1</abio_atm_model_year>
 <abio_atm_data_year>1</abio_atm_data_year>
 
+<!--------------------------------->
+<!-- abio_dic_dic14 derived vars -->
+<!--------------------------------->
+
+<abio_dic_dic14_ltavg_NK>.false.</abio_dic_dic14_ltavg_NK>
+
 <!---------------------------->
 <!-- ecosys derived vars    -->
 <!---------------------------->

--- a/bld/namelist_files/namelist_definition_pop.xml
+++ b/bld/namelist_files/namelist_definition_pop.xml
@@ -5883,6 +5883,20 @@ Year in data that corresponds to abio_atm_model_year.
 Default: 1
 </entry>
 
+<!-- - - - - - - - - - - - - - - - - - - - -->
+<!-- Group: abio_dic_dic14 derived vars  - -->
+<!-- - - - - - - - - - - - - - - - - - - - -->
+
+<entry
+id="abio_dic_dic14_ltavg_NK"
+type="logical"
+category="Passive Tracers (Abiotic DIC & DIC14)"
+group="derived" >
+add Newton-Krylov spinup related tavg variables
+Default:
+.false.
+</entry>
+
 
 <!-- - - - - - - - - - - - - - - - - - -->
 <!-- Group: ecosys derived vars      - -->

--- a/cime_config/testdefs/testlist_pop.xml
+++ b/cime_config/testdefs/testlist_pop.xml
@@ -278,6 +278,11 @@
       <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
     </machines>
   </test>
+  <test name="ERS_Ld5_D" grid="T62_g37" compset="C" testmods="pop/abio_dic_dic14_ltavg_NK">
+    <machines>
+      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+    </machines>
+  </test>
   <test name="ERS_Ld5_D" grid="T62_g37" compset="C1850ECO" testmods="pop/ciso_abio_dic_dic14">
     <machines>
       <machine name="cheyenne" compiler="intel" category="aux_pop"/>

--- a/cime_config/testdefs/testmods_dirs/pop/abio_dic_dic14_ltavg_NK/include_user_mods
+++ b/cime_config/testdefs/testmods_dirs/pop/abio_dic_dic14_ltavg_NK/include_user_mods
@@ -1,0 +1,1 @@
+../abio_dic_dic14

--- a/cime_config/testdefs/testmods_dirs/pop/abio_dic_dic14_ltavg_NK/user_nl_pop
+++ b/cime_config/testdefs/testmods_dirs/pop/abio_dic_dic14_ltavg_NK/user_nl_pop
@@ -1,0 +1,1 @@
+abio_dic_dic14_ltavg_NK = .true.

--- a/input_templates/ocn.abio_dic_dic14.tavg.csh
+++ b/input_templates/ocn.abio_dic_dic14.tavg.csh
@@ -15,6 +15,8 @@ endif
 
 @ s1 = 1   # use base-model stream 1
 
+set abio_dic_dic14_ltavg_NK = $2
+
 cat >! $CASEROOT/Buildconf/popconf/abio_dic_dic14_tavg_contents << EOF
 $s1  ABIO_DIC
 $s1  ABIO_DIC14
@@ -37,6 +39,14 @@ $s1  STF_ABIO_DIC
 $s1  STF_ABIO_DIC14
 $s1  Jint_ABIO_DIC14
 EOF
+
+if ($abio_dic_dic14_ltavg_NK == ".true.") then
+cat >> $CASEROOT/Buildconf/popconf/abio_dic_dic14_tavg_contents << EOF
+$s1  d_SF_ABIO_DIC_d_ABIO_DIC
+$s1  d_SF_ABIO_DIC14_d_ABIO_DIC
+$s1  d_SF_ABIO_DIC14_d_ABIO_DIC14
+EOF
+endif
 
 if ($OCN_TAVG_TRACER_BUDGET == TRUE) then
 cat >> $CASEROOT/Buildconf/popconf/abio_dic_dic14_tavg_contents << EOF


### PR DESCRIPTION
Description of changes:
add tavg vars needed for Newton-Krylov solver to abio_dic_dic14

Move io_read_fallback_register_field call for 'ABIO_PH_SURF' outside of all_fields_exist_in_restfile conditional. This fallback should always be available, and the Newton-Krylov solver relies on it.

Testing:
Test case/suite: passes aux_pop on cheyenne/intel, compared to pop2_cesm2_1_rel_n10
Test status: bit for bit

new test ERS_Ld5_D.T62_g37.C.cheyenne_intel.pop-abio_dic_dic14_ltavg_NK added to aux_pop

Fixes: NA

User interface (namelist or namelist defaults) changes?
computation and inclusion of vars in tavg file controlled with nml var abio_dic_dic14_ltavg_NK
(nml var not written to pop_in, just passed to tavg_contents generating script)
