### PR TITLE
GreenPlanet support

### DIFF
--- a/bld/generate_pop_decomp.xml
+++ b/bld/generate_pop_decomp.xml
@@ -184,6 +184,15 @@
     <decomptype>cartesian</decomptype>
   </decomp>
 
+  <decomp nproc="80" res="gx3v7" >
+    <maxblocks >1</maxblocks>
+    <bsize_x   >10</bsize_x>
+    <bsize_y   >15</bsize_y>
+    <nx_blocks >10</nx_blocks>
+    <ny_blocks >8</ny_blocks>
+    <decomptype>cartesian</decomptype>
+  </decomp>
+
 <!-- ====================================================================== -->
 
   <!-- gx1v[67] resolution -->

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -166,7 +166,7 @@
     </mach>
 
     <!-- gx3v7 resolution on greenplanet -->
-    <mach name="greenplanet-sib29\b">
+    <mach name="greenplanet-sib29">
 
       <!-- C and C+ECO (e.g., C1850ECO) with gx3v7 on sib2.9 queue of GreenPlanet:
            all components share 4 nodes -->
@@ -730,6 +730,156 @@
         </nthrds>
         <rootpe>
           <rootpe_ocn>-4</rootpe_ocn>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+        </rootpe>
+      </pes>
+    </mach>
+    <mach name="greenplanet-sky24">
+
+      <!-- C compset, gx1v6, gx1v7, or tx1v1 on sky2.4 queue of GreenPlanet:
+           POP gets 4 nodes (160 cores)
+           all other components share 1 node (40 cores) -->
+      <pes pesize="any" compset="_DATM.*_DICE.*_POP2[^%]">
+        <comment>C; gx1v6, gx1v7, or tx1v1 resolution on GreenPlanet (sky2.4 queue)</comment>
+        <ntasks>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_ice>-1</ntasks_ice>
+          <ntasks_cpl>-1</ntasks_cpl>
+          <ntasks_wav>-1</ntasks_wav>
+          <ntasks_atm>-1</ntasks_atm>
+          <ntasks_glc>-1</ntasks_glc>
+          <ntasks_lnd>-1</ntasks_lnd>
+          <ntasks_rof>-1</ntasks_rof>
+        </ntasks>
+        <nthrds>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_cpl>1</nthrds_cpl>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+        </nthrds>
+        <rootpe>
+          <rootpe_ocn>-1</rootpe_ocn>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+        </rootpe>
+      </pes>
+
+      <!-- C+ECO (e.g., C1850ECO) compset with gx1v6, gx1v7, or tx1v1 resolution on sky2.4 queue of GreenPlanet:
+           POP gets 9 nodes (360 cores)
+           all other components share 1 node (40 cores) -->
+      <pes pesize="any" compset="_DATM.*_DICE.*_POP2%ECO">
+        <comment>C+ECO (e.g., C1850ECO); gx1v6, gx1v7, or tx1v1 resolution on GreenPlanet (sky2.4 queue)</comment>
+        <ntasks>
+          <ntasks_ocn>-9</ntasks_ocn>
+          <ntasks_ice>-1</ntasks_ice>
+          <ntasks_cpl>-1</ntasks_cpl>
+          <ntasks_wav>-1</ntasks_wav>
+          <ntasks_atm>-1</ntasks_atm>
+          <ntasks_glc>-1</ntasks_glc>
+          <ntasks_lnd>-1</ntasks_lnd>
+          <ntasks_rof>-1</ntasks_rof>
+        </ntasks>
+        <nthrds>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_cpl>1</nthrds_cpl>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+        </nthrds>
+        <rootpe>
+          <rootpe_ocn>-1</rootpe_ocn>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+        </rootpe>
+      </pes>
+
+      <!-- G compset, gx1v6, gx1v7, or tx1v1 on sky2.4 queue of GreenPlanet:
+           POP gets 4 nodes (160 cores)
+           all other components share 2 nodes (80 cores) -->
+      <pes pesize="any" compset="_DATM.*_CICE.*_POP2[^%]">
+        <comment>G; gx1v6, gx1v7, or tx1v1 resolution on GreenPlanet (sky2.4 queue)</comment>
+        <ntasks>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_cpl>-2</ntasks_cpl>
+          <ntasks_wav>-2</ntasks_wav>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_glc>-2</ntasks_glc>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+        </ntasks>
+        <nthrds>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_cpl>1</nthrds_cpl>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+        </nthrds>
+        <rootpe>
+          <rootpe_ocn>-2</rootpe_ocn>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+        </rootpe>
+      </pes>
+
+      <!-- G+ECO (e.g., G1850ECO) compset, gx1v6, gx1v7, or tx1v1 resolution on sky2.4 queue of GreenPlanet:
+           POP gets 9 nodes (360 cores)
+           all other components share 2 nodes (80 cores) -->
+      <pes pesize="any" compset="_DATM.*_CICE.*_POP2%ECO">
+        <comment>G+ECO (e.g., G1850ECO); gx1v6, gx1v7, or tx1v1 resolution on GreenPlanet (sky2.4 queue)</comment>
+        <ntasks>
+          <ntasks_ocn>-9</ntasks_ocn>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_cpl>-2</ntasks_cpl>
+          <ntasks_wav>-2</ntasks_wav>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_glc>-2</ntasks_glc>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+        </ntasks>
+        <nthrds>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_cpl>1</nthrds_cpl>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+        </nthrds>
+        <rootpe>
+          <rootpe_ocn>-2</rootpe_ocn>
           <rootpe_ice>0</rootpe_ice>
           <rootpe_cpl>0</rootpe_cpl>
           <rootpe_wav>0</rootpe_wav>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -171,7 +171,7 @@
       <!-- C and C+ECO (e.g., C1850ECO) with gx3v7 on sib2.9 queue of GreenPlanet:
            all components share 4 nodes -->
       <pes pesize="any" compset="_DATM.*_DICE.*_POP2">
-        <comment>C or C+ECO (e.g., C1850ECO); gx3v7 resolution on GreenPlanet (sib2.9)</comment>
+        <comment>C or C+ECO (e.g., C1850ECO); gx3v7 resolution on GreenPlanet (sib2.9 queue)</comment>
         <ntasks>
           <ntasks_ocn>-4</ntasks_ocn>
           <ntasks_ice>-4</ntasks_ice>
@@ -246,7 +246,7 @@
            POP gets 4 nodes
            all other components share 2 nodes -->
       <pes pesize="any" compset="_DATM.*_CICE.*_POP2%ECO">
-        <comment>G+ECO (e.g., G1850ECO); gx3v7 resolution on GreenPlanet (sib2.9)</comment>
+        <comment>G+ECO (e.g., G1850ECO); gx3v7 resolution on GreenPlanet (sib2.9 queue)</comment>
         <ntasks>
           <ntasks_ocn>-4</ntasks_ocn>
           <ntasks_ice>-2</ntasks_ice>
@@ -589,7 +589,159 @@
       </pes>
     </mach>
 
-    <!-- gx1v6, gx1v7, or tx1v1 resolution on cheyenne  -->
+    <!-- gx1v6, gx1v7, or tx1v1 resolution on greenplanet -->
+    <mach name="greenplanet-sib29">
+
+      <!-- C compset, gx1v6, gx1v7, or tx1v1 on sib2.9 queue of GreenPlanet:
+           POP gets 9 nodes (144 cores)
+           all other components share 1 node (16 cores) -->
+      <pes pesize="any" compset="_DATM.*_DICE.*_POP2[^%]">
+        <comment>C; gx1v6, gx1v7, or tx1v1 resolution on GreenPlanet (sib2.9 queue)</comment>
+        <ntasks>
+          <ntasks_ocn>-9</ntasks_ocn>
+          <ntasks_ice>-1</ntasks_ice>
+          <ntasks_cpl>-1</ntasks_cpl>
+          <ntasks_wav>-1</ntasks_wav>
+          <ntasks_atm>-1</ntasks_atm>
+          <ntasks_glc>-1</ntasks_glc>
+          <ntasks_lnd>-1</ntasks_lnd>
+          <ntasks_rof>-1</ntasks_rof>
+        </ntasks>
+        <nthrds>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_cpl>1</nthrds_cpl>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+        </nthrds>
+        <rootpe>
+          <rootpe_ocn>-1</rootpe_ocn>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+        </rootpe>
+      </pes>
+
+      <!-- C+ECO (e.g., C1850ECO) compset with gx1v6, gx1v7, or tx1v1 resolution on sib2.9 queue of GreenPlanet:
+           POP gets 27 nodes (432 cores)
+           all other components share 1 node (16 cores) -->
+      <pes pesize="any" compset="_DATM.*_DICE.*_POP2%ECO">
+        <comment>C+ECO (e.g., C1850ECO); gx1v6, gx1v7, or tx1v1 resolution on GreenPlanet (sib2.9 queue)</comment>
+        <ntasks>
+          <ntasks_ocn>-27</ntasks_ocn>
+          <ntasks_ice>-1</ntasks_ice>
+          <ntasks_cpl>-1</ntasks_cpl>
+          <ntasks_wav>-1</ntasks_wav>
+          <ntasks_atm>-1</ntasks_atm>
+          <ntasks_glc>-1</ntasks_glc>
+          <ntasks_lnd>-1</ntasks_lnd>
+          <ntasks_rof>-1</ntasks_rof>
+        </ntasks>
+        <nthrds>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_cpl>1</nthrds_cpl>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+        </nthrds>
+        <rootpe>
+          <rootpe_ocn>-1</rootpe_ocn>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+        </rootpe>
+      </pes>
+
+      <!-- G compset, gx1v6, gx1v7, or tx1v1 on sib2.9 queue of GreenPlanet:
+           POP gets 9 nodes (144 cores)
+           all other components share 4 nodes (72 cores) -->
+      <pes pesize="any" compset="_DATM.*_CICE.*_POP2[^%]">
+        <comment>G; gx1v6, gx1v7, or tx1v1 resolution on GreenPlanet (sib2.9 queue)</comment>
+        <ntasks>
+          <ntasks_ocn>-9</ntasks_ocn>
+          <ntasks_ice>-4</ntasks_ice>
+          <ntasks_cpl>-4</ntasks_cpl>
+          <ntasks_wav>-4</ntasks_wav>
+          <ntasks_atm>-4</ntasks_atm>
+          <ntasks_glc>-4</ntasks_glc>
+          <ntasks_lnd>-4</ntasks_lnd>
+          <ntasks_rof>-4</ntasks_rof>
+        </ntasks>
+        <nthrds>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_cpl>1</nthrds_cpl>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+        </nthrds>
+        <rootpe>
+          <rootpe_ocn>-4</rootpe_ocn>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+        </rootpe>
+      </pes>
+
+      <!-- G+ECO (e.g., G1850ECO) compset, gx1v6, gx1v7, or tx1v1 resolution on sib2.9 queue of GreenPlanet:
+           POP gets 27 nodes (432 cores)
+           all other components share 4 nodes (64 cores) -->
+      <pes pesize="any" compset="_DATM.*_CICE.*_POP2%ECO">
+        <comment>G+ECO (e.g., G1850ECO); gx1v6, gx1v7, or tx1v1 resolution on GreenPlanet (sib2.9 queue)</comment>
+        <ntasks>
+          <ntasks_ocn>-27</ntasks_ocn>
+          <ntasks_ice>-4</ntasks_ice>
+          <ntasks_cpl>-4</ntasks_cpl>
+          <ntasks_wav>-4</ntasks_wav>
+          <ntasks_atm>-4</ntasks_atm>
+          <ntasks_glc>-4</ntasks_glc>
+          <ntasks_lnd>-4</ntasks_lnd>
+          <ntasks_rof>-4</ntasks_rof>
+        </ntasks>
+        <nthrds>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_cpl>1</nthrds_cpl>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+        </nthrds>
+        <rootpe>
+          <rootpe_ocn>-4</rootpe_ocn>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+        </rootpe>
+      </pes>
+    </mach>
+
+    <!-- gx1v6, gx1v7, or tx1v1 resolution on hobart  -->
     <mach name="hobart">
 
       <!-- C, C+ECO (e.g., C1850ECO) with gx1v6, gx1v7, or tx1v1 on hobart:

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -165,6 +165,234 @@
       </pes>
     </mach>
 
+    <!-- gx3v7 resolution on greenplanet -->
+    <mach name="greenplanet\b">
+
+      <!-- C and C+ECO (e.g., C1850ECO) with gx3v7 on GreenPlanet:
+           all components share 4 nodes -->
+      <pes pesize="any" compset="_DATM.*_DICE.*_POP2">
+        <comment>C or C+ECO (e.g., C1850ECO); gx3v7 resolution on GreenPlanet</comment>
+        <ntasks>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_ice>-4</ntasks_ice>
+          <ntasks_cpl>-4</ntasks_cpl>
+          <ntasks_wav>-4</ntasks_wav>
+          <ntasks_atm>-4</ntasks_atm>
+          <ntasks_glc>-4</ntasks_glc>
+          <ntasks_lnd>-4</ntasks_lnd>
+          <ntasks_rof>-4</ntasks_rof>
+        </ntasks>
+        <nthrds>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_cpl>1</nthrds_cpl>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+        </nthrds>
+        <rootpe>
+          <rootpe_ocn>0</rootpe_ocn>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+        </rootpe>
+      </pes>
+
+      <!-- G with gx3v7 on GreenPlanet:
+           POP gets 4 nodes
+           CICE and coupler share 2 nodes
+           all other components share 2 nodes -->
+      <pes pesize="any" compset="_DATM.*_CICE.*_POP2[^%]">
+        <comment>G; gx3v7 resolution on GreenPlanet</comment>
+        <ntasks>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_cpl>-2</ntasks_cpl>
+          <ntasks_wav>-2</ntasks_wav>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_glc>-2</ntasks_glc>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+        </ntasks>
+        <nthrds>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_cpl>1</nthrds_cpl>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+        </nthrds>
+        <rootpe>
+          <rootpe_ocn>-4</rootpe_ocn>
+          <rootpe_ice>-2</rootpe_ice>
+          <rootpe_cpl>-2</rootpe_cpl>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+        </rootpe>
+      </pes>
+
+      <!-- G+ECO (e.g., G1850ECO) with gx3v7 on GreenPlanet:
+           POP gets 4 nodes
+           all other components share 2 nodes -->
+      <pes pesize="any" compset="_DATM.*_CICE.*_POP2%ECO">
+        <comment>G+ECO (e.g., G1850ECO); gx3v7 resolution on GreenPlanet</comment>
+        <ntasks>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_cpl>-2</ntasks_cpl>
+          <ntasks_wav>-2</ntasks_wav>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_glc>-2</ntasks_glc>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+        </ntasks>
+        <nthrds>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_cpl>1</nthrds_cpl>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+        </nthrds>
+        <rootpe>
+          <rootpe_ocn>-2</rootpe_ocn>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+        </rootpe>
+      </pes>
+    </mach>
+    <mach name="greenplanet40">
+
+      <!-- C and C+ECO (e.g., C1850ECO) with gx3v7 on GreenPlanet (sky2.4 queue):
+           all components share 2 nodes -->
+      <pes pesize="any" compset="_DATM.*_DICE.*_POP2">
+        <comment>C or C+ECO (e.g., C1850ECO); gx3v7 resolution on GreenPlanet (sky2.4)</comment>
+        <ntasks>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_ice>-2</ntasks_ice>
+          <ntasks_cpl>-2</ntasks_cpl>
+          <ntasks_wav>-2</ntasks_wav>
+          <ntasks_atm>-2</ntasks_atm>
+          <ntasks_glc>-2</ntasks_glc>
+          <ntasks_lnd>-2</ntasks_lnd>
+          <ntasks_rof>-2</ntasks_rof>
+        </ntasks>
+        <nthrds>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_cpl>1</nthrds_cpl>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+        </nthrds>
+        <rootpe>
+          <rootpe_ocn>0</rootpe_ocn>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+        </rootpe>
+      </pes>
+
+      <!-- G with gx3v7 on GreenPlanet (sky2.4 queue):
+           POP gets 2 nodes
+           CICE and coupler share 1 nodes
+           all other components share 1 nodes -->
+      <pes pesize="any" compset="_DATM.*_CICE.*_POP2[^%]">
+        <comment>G; gx3v7 resolution on GreenPlanet (sky2.4)</comment>
+        <ntasks>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_ice>-1</ntasks_ice>
+          <ntasks_cpl>-1</ntasks_cpl>
+          <ntasks_wav>-1</ntasks_wav>
+          <ntasks_atm>-1</ntasks_atm>
+          <ntasks_glc>-1</ntasks_glc>
+          <ntasks_lnd>-1</ntasks_lnd>
+          <ntasks_rof>-1</ntasks_rof>
+        </ntasks>
+        <nthrds>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_cpl>1</nthrds_cpl>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+        </nthrds>
+        <rootpe>
+          <rootpe_ocn>-2</rootpe_ocn>
+          <rootpe_ice>-1</rootpe_ice>
+          <rootpe_cpl>-1</rootpe_cpl>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+        </rootpe>
+      </pes>
+
+      <!-- G+ECO (e.g., G1850ECO) with gx3v7 on GreenPlanet (sky2.4 queue):
+           POP gets 2 nodes
+           all other components share 1 nodes -->
+      <pes pesize="any" compset="_DATM.*_CICE.*_POP2%ECO">
+        <comment>G+ECO (e.g., G1850ECO); gx3v7 resolution on GreenPlanet (sky2.4)</comment>
+        <ntasks>
+          <ntasks_ocn>-2</ntasks_ocn>
+          <ntasks_ice>-1</ntasks_ice>
+          <ntasks_cpl>-1</ntasks_cpl>
+          <ntasks_wav>-1</ntasks_wav>
+          <ntasks_atm>-1</ntasks_atm>
+          <ntasks_glc>-1</ntasks_glc>
+          <ntasks_lnd>-1</ntasks_lnd>
+          <ntasks_rof>-1</ntasks_rof>
+        </ntasks>
+        <nthrds>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_cpl>1</nthrds_cpl>
+          <nthrds_wav>1</nthrds_wav>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+        </nthrds>
+        <rootpe>
+          <rootpe_ocn>-1</rootpe_ocn>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_wav>0</rootpe_wav>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+        </rootpe>
+      </pes>
+    </mach>
+
     <!-- gx3v7 resolution on hobart -->
     <mach name="hobart">
 

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -166,12 +166,12 @@
     </mach>
 
     <!-- gx3v7 resolution on greenplanet -->
-    <mach name="greenplanet\b">
+    <mach name="greenplanet-sib29\b">
 
-      <!-- C and C+ECO (e.g., C1850ECO) with gx3v7 on GreenPlanet:
+      <!-- C and C+ECO (e.g., C1850ECO) with gx3v7 on sib2.9 queue of GreenPlanet:
            all components share 4 nodes -->
       <pes pesize="any" compset="_DATM.*_DICE.*_POP2">
-        <comment>C or C+ECO (e.g., C1850ECO); gx3v7 resolution on GreenPlanet</comment>
+        <comment>C or C+ECO (e.g., C1850ECO); gx3v7 resolution on GreenPlanet (sib2.9)</comment>
         <ntasks>
           <ntasks_ocn>-4</ntasks_ocn>
           <ntasks_ice>-4</ntasks_ice>
@@ -204,12 +204,12 @@
         </rootpe>
       </pes>
 
-      <!-- G with gx3v7 on GreenPlanet:
+      <!-- G with gx3v7 on sib2.9 queue of GreenPlanet:
            POP gets 4 nodes
            CICE and coupler share 2 nodes
            all other components share 2 nodes -->
       <pes pesize="any" compset="_DATM.*_CICE.*_POP2[^%]">
-        <comment>G; gx3v7 resolution on GreenPlanet</comment>
+        <comment>G; gx3v7 resolution on GreenPlanet (sib2.9 queue)</comment>
         <ntasks>
           <ntasks_ocn>-4</ntasks_ocn>
           <ntasks_ice>-2</ntasks_ice>
@@ -242,11 +242,11 @@
         </rootpe>
       </pes>
 
-      <!-- G+ECO (e.g., G1850ECO) with gx3v7 on GreenPlanet:
+      <!-- G+ECO (e.g., G1850ECO) with gx3v7 on sib2.9 queue of GreenPlanet:
            POP gets 4 nodes
            all other components share 2 nodes -->
       <pes pesize="any" compset="_DATM.*_CICE.*_POP2%ECO">
-        <comment>G+ECO (e.g., G1850ECO); gx3v7 resolution on GreenPlanet</comment>
+        <comment>G+ECO (e.g., G1850ECO); gx3v7 resolution on GreenPlanet (sib2.9)</comment>
         <ntasks>
           <ntasks_ocn>-4</ntasks_ocn>
           <ntasks_ice>-2</ntasks_ice>
@@ -279,12 +279,12 @@
         </rootpe>
       </pes>
     </mach>
-    <mach name="greenplanet40">
+    <mach name="greenplanet-sky24">
 
-      <!-- C and C+ECO (e.g., C1850ECO) with gx3v7 on GreenPlanet (sky2.4 queue):
+      <!-- C and C+ECO (e.g., C1850ECO) with gx3v7 on sky2.4 queue of GreenPlanet:
            all components share 2 nodes -->
       <pes pesize="any" compset="_DATM.*_DICE.*_POP2">
-        <comment>C or C+ECO (e.g., C1850ECO); gx3v7 resolution on GreenPlanet (sky2.4)</comment>
+        <comment>C or C+ECO (e.g., C1850ECO); gx3v7 resolution on GreenPlanet (sky2.4 queue)</comment>
         <ntasks>
           <ntasks_ocn>-2</ntasks_ocn>
           <ntasks_ice>-2</ntasks_ice>
@@ -317,12 +317,12 @@
         </rootpe>
       </pes>
 
-      <!-- G with gx3v7 on GreenPlanet (sky2.4 queue):
+      <!-- G with gx3v7 on sky2.4 queue of GreenPlanet:
            POP gets 2 nodes
            CICE and coupler share 1 nodes
            all other components share 1 nodes -->
       <pes pesize="any" compset="_DATM.*_CICE.*_POP2[^%]">
-        <comment>G; gx3v7 resolution on GreenPlanet (sky2.4)</comment>
+        <comment>G; gx3v7 resolution on GreenPlanet (sky2.4 queue)</comment>
         <ntasks>
           <ntasks_ocn>-2</ntasks_ocn>
           <ntasks_ice>-1</ntasks_ice>
@@ -355,11 +355,11 @@
         </rootpe>
       </pes>
 
-      <!-- G+ECO (e.g., G1850ECO) with gx3v7 on GreenPlanet (sky2.4 queue):
+      <!-- G+ECO (e.g., G1850ECO) with gx3v7 on sky2.4 queue of GreenPlanet:
            POP gets 2 nodes
            all other components share 1 nodes -->
       <pes pesize="any" compset="_DATM.*_CICE.*_POP2%ECO">
-        <comment>G+ECO (e.g., G1850ECO); gx3v7 resolution on GreenPlanet (sky2.4)</comment>
+        <comment>G+ECO (e.g., G1850ECO); gx3v7 resolution on GreenPlanet (sky2.4 queue)</comment>
         <ntasks>
           <ntasks_ocn>-2</ntasks_ocn>
           <ntasks_ice>-1</ntasks_ice>


### PR DESCRIPTION
### Description of changes:

Adding PE layouts and other necessary settings to run on UCI's cluster, [GreenPlanet](https://ps.uci.edu/greenplanet/). Currently supporting two of the [SLURM partitions](https://ps.uci.edu/greenplanet/slurm_partitions) (`sky2.4` and `sib2.9`), future PR may add `nes2.8` support as well.

### Testing:
 
Test case/suite: No full test suite, but I've run `C1850ECO` cases on both partitions using `gx3v7` and `gx1v7` resolutions. I'm happy to run `aux_pop` on cheyenne to verify I didn't break anything on that machine
Test status: N/A

Fixes [POP2 Github issue #] N/A

User interface (namelist or namelist defaults) changes? None

