### PR TITLE
Add support for OCN_TRANSIENT=ssp534

### DIFF
--- a/bld/namelist_files/namelist_defaults_pop.xml
+++ b/bld/namelist_files/namelist_defaults_pop.xml
@@ -1309,6 +1309,7 @@
 <abio_atm_d14c_filename ocn_transient="ssp126">lnd/clm2/isotopes/atm_delta_C14_CMIP6_SSP126_3x1_global_1850-2100_yearly_c181209.nc</abio_atm_d14c_filename>
 <abio_atm_d14c_filename ocn_transient="ssp245">lnd/clm2/isotopes/atm_delta_C14_CMIP6_SSP245_3x1_global_1850-2100_yearly_c181209.nc</abio_atm_d14c_filename>
 <abio_atm_d14c_filename ocn_transient="ssp370">lnd/clm2/isotopes/atm_delta_C14_CMIP6_SSP3B_3x1_global_1850-2100_yearly_c181209.nc</abio_atm_d14c_filename>
+<abio_atm_d14c_filename ocn_transient="ssp534">lnd/clm2/isotopes/atm_delta_C14_CMIP6_SSP534os_3x1_global_1850-2100_yearly_c181209.nc</abio_atm_d14c_filename>
 <abio_atm_d14c_filename ocn_transient="ssp585">lnd/clm2/isotopes/atm_delta_C14_CMIP6_SSP5B_3x1_global_1850-2100_yearly_c181209.nc</abio_atm_d14c_filename>
 
 <abio_atm_co2_filename>ocn/pop/res_indpt/forcing/splco2_20140912.dat</abio_atm_co2_filename>
@@ -1318,6 +1319,7 @@
 <abio_atm_co2_opt ocn_transient="ssp126">'drv_diag'</abio_atm_co2_opt>
 <abio_atm_co2_opt ocn_transient="ssp245">'drv_diag'</abio_atm_co2_opt>
 <abio_atm_co2_opt ocn_transient="ssp370">'drv_diag'</abio_atm_co2_opt>
+<abio_atm_co2_opt ocn_transient="ssp534">'drv_diag'</abio_atm_co2_opt>
 <abio_atm_co2_opt ocn_transient="ssp585">'drv_diag'</abio_atm_co2_opt>
 
 <abio_atm_d14c_opt>'lat_bands'</abio_atm_d14c_opt>
@@ -1325,6 +1327,7 @@
 <abio_atm_d14c_opt ocn_transient="ssp126">'file'</abio_atm_d14c_opt>
 <abio_atm_d14c_opt ocn_transient="ssp245">'file'</abio_atm_d14c_opt>
 <abio_atm_d14c_opt ocn_transient="ssp370">'file'</abio_atm_d14c_opt>
+<abio_atm_d14c_opt ocn_transient="ssp534">'file'</abio_atm_d14c_opt>
 <abio_atm_d14c_opt ocn_transient="ssp585">'file'</abio_atm_d14c_opt>
 
 <abio_atm_d14c_const>0.0</abio_atm_d14c_const>
@@ -1511,6 +1514,14 @@
 <ndep_shr_stream_file ocn_grid="gx1v6" ocn_transient="ssp370">ocn/pop/gx1v6/forcing/ndep_ocn_ssp370_w_nhx_emis_gx1v6_c190412.nc</ndep_shr_stream_file>
 <ndep_shr_stream_file ocn_grid="gx1v7" ocn_transient="ssp370">ocn/pop/gx1v6/forcing/ndep_ocn_ssp370_w_nhx_emis_gx1v6_c190412.nc</ndep_shr_stream_file>
 
+<ndep_data_type ocn_transient="ssp534">shr_stream</ndep_data_type>
+<ndep_shr_stream_year_first ocn_transient="ssp534">2039</ndep_shr_stream_year_first>
+<ndep_shr_stream_year_last  ocn_transient="ssp534">2101</ndep_shr_stream_year_last>
+<ndep_shr_stream_year_align ocn_transient="ssp534">2039</ndep_shr_stream_year_align>
+<ndep_shr_stream_file ocn_grid="gx3v7" ocn_transient="ssp534">ocn/pop/gx3v7/forcing/ndep_ocn_ssp534os_w_nhx_emis_gx3v7_c210223.nc</ndep_shr_stream_file>
+<ndep_shr_stream_file ocn_grid="gx1v6" ocn_transient="ssp534">ocn/pop/gx1v6/forcing/ndep_ocn_ssp534os_w_nhx_emis_gx1v6_c210223.nc</ndep_shr_stream_file>
+<ndep_shr_stream_file ocn_grid="gx1v7" ocn_transient="ssp534">ocn/pop/gx1v6/forcing/ndep_ocn_ssp534os_w_nhx_emis_gx1v6_c210223.nc</ndep_shr_stream_file>
+
 <ndep_data_type ocn_transient="ssp585">shr_stream</ndep_data_type>
 <ndep_shr_stream_year_first ocn_transient="ssp585">2014</ndep_shr_stream_year_first>
 <ndep_shr_stream_year_last  ocn_transient="ssp585">2101</ndep_shr_stream_year_last>
@@ -1585,6 +1596,7 @@
 <ciso_atm_d13c_opt ocn_transient="ssp126">'file'</ciso_atm_d13c_opt>
 <ciso_atm_d13c_opt ocn_transient="ssp245">'file'</ciso_atm_d13c_opt>
 <ciso_atm_d13c_opt ocn_transient="ssp370">'file'</ciso_atm_d13c_opt>
+<ciso_atm_d13c_opt ocn_transient="ssp534">'file'</ciso_atm_d13c_opt>
 <ciso_atm_d13c_opt ocn_transient="ssp585">'file'</ciso_atm_d13c_opt>
 
 <ciso_atm_d13c_const>-6.610</ciso_atm_d13c_const>
@@ -1594,6 +1606,7 @@
 <ciso_atm_d14c_opt ocn_transient="ssp126">'file'</ciso_atm_d14c_opt>
 <ciso_atm_d14c_opt ocn_transient="ssp245">'file'</ciso_atm_d14c_opt>
 <ciso_atm_d14c_opt ocn_transient="ssp370">'file'</ciso_atm_d14c_opt>
+<ciso_atm_d14c_opt ocn_transient="ssp534">'file'</ciso_atm_d14c_opt>
 <ciso_atm_d14c_opt ocn_transient="ssp585">'file'</ciso_atm_d14c_opt>
 
 <ciso_atm_d14c_const>0.0</ciso_atm_d14c_const>
@@ -1604,12 +1617,14 @@
 <ciso_atm_d13c_filename ocn_transient="ssp126">lnd/clm2/isotopes/atm_delta_C13_CMIP6_SSP126_1850-2100_yearly_c181209.nc</ciso_atm_d13c_filename>
 <ciso_atm_d13c_filename ocn_transient="ssp245">lnd/clm2/isotopes/atm_delta_C13_CMIP6_SSP245_1850-2100_yearly_c181209.nc</ciso_atm_d13c_filename>
 <ciso_atm_d13c_filename ocn_transient="ssp370">lnd/clm2/isotopes/atm_delta_C13_CMIP6_SSP3B_1850-2100_yearly_c181209.nc</ciso_atm_d13c_filename>
+<ciso_atm_d13c_filename ocn_transient="ssp534">lnd/clm2/isotopes/atm_delta_C13_CMIP6_SSP534os_1850-2100_yearly_c181209.nc</ciso_atm_d13c_filename>
 <ciso_atm_d13c_filename ocn_transient="ssp585">lnd/clm2/isotopes/atm_delta_C13_CMIP6_SSP5B_1850-2100_yearly_c181209.nc</ciso_atm_d13c_filename>
 
 <ciso_atm_d14c_filename>lnd/clm2/isotopes/atm_delta_C14_CMIP6_3x1_global_1850-2015_yearly_v2.0_c190528.nc</ciso_atm_d14c_filename>
 <ciso_atm_d14c_filename ocn_transient="ssp126">lnd/clm2/isotopes/atm_delta_C14_CMIP6_SSP126_3x1_global_1850-2100_yearly_c181209.nc</ciso_atm_d14c_filename>
 <ciso_atm_d14c_filename ocn_transient="ssp245">lnd/clm2/isotopes/atm_delta_C14_CMIP6_SSP245_3x1_global_1850-2100_yearly_c181209.nc</ciso_atm_d14c_filename>
 <ciso_atm_d14c_filename ocn_transient="ssp370">lnd/clm2/isotopes/atm_delta_C14_CMIP6_SSP3B_3x1_global_1850-2100_yearly_c181209.nc</ciso_atm_d14c_filename>
+<ciso_atm_d14c_filename ocn_transient="ssp534">lnd/clm2/isotopes/atm_delta_C14_CMIP6_SSP534os_3x1_global_1850-2100_yearly_c181209.nc</ciso_atm_d14c_filename>
 <ciso_atm_d14c_filename ocn_transient="ssp585">lnd/clm2/isotopes/atm_delta_C14_CMIP6_SSP5B_3x1_global_1850-2100_yearly_c181209.nc</ciso_atm_d14c_filename>
 
 <ciso_atm_model_year>1</ciso_atm_model_year>

--- a/bld/namelist_files/namelist_definition_pop.xml
+++ b/bld/namelist_files/namelist_definition_pop.xml
@@ -6367,7 +6367,7 @@ type="integer"
 category="Forcing (Ecosystem)"
 group="ecosys_forcing_data_nml" >
 Default: 1849 for OCN_TRANSIENT=1850-2000, 2004 for rcp runs, 2014 for ssp runs,
-1637 for OCN_TRANSIENT=CORE2OMIP, 1652 for OCN_TRANSIENT=JRA_OMIP
+2039 for ssp534, 1637 for OCN_TRANSIENT=CORE2OMIP, 1652 for OCN_TRANSIENT=JRA_OMIP
 </entry>
 
 <entry
@@ -6385,7 +6385,7 @@ type="integer"
 category="Forcing (Ecosystem)"
 group="ecosys_forcing_data_nml" >
 Default: 1849 for OCN_TRANSIENT=1850-2000, 2004 for rcp runs, 2014 for ssp runs,
-0 for OCN_TRANSIENT=CORE2OMIP,JRA_OMIP
+2039 for ssp534, 0 for OCN_TRANSIENT=CORE2OMIP,JRA_OMIP
 </entry>
 
 <entry

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -138,7 +138,7 @@
 
   <entry id="OCN_TRANSIENT">
     <type>char</type>
-    <valid_values>unset,CORE2_NYF,CORE2,CORE2_OMIP,JRA,JRA_OMIP,1850-2000,rcp4.5,rcp8.5,ssp126,ssp245,ssp370,ssp534ext,ssp585,ssp585ext</valid_values>
+    <valid_values>unset,CORE2_NYF,CORE2,CORE2_OMIP,JRA,JRA_OMIP,1850-2000,rcp4.5,rcp8.5,ssp126,ssp245,ssp370,ssp534,ssp534ext,ssp585,ssp585ext</valid_values>
     <default_value>unset</default_value>
     <values>
       <value compset="DATM%NYF">CORE2_NYF</value>
@@ -153,6 +153,7 @@
       <value compset="^SSP126_CAM">ssp126</value>
       <value compset="^SSP245_CAM">ssp245</value>
       <value compset="^SSP370_CAM">ssp370</value>
+      <value compset="^SSP534_CAM">ssp534</value>
       <value compset="^SSP534EXT_CAM">ssp534ext</value>
       <value compset="^SSP585_CAM">ssp585</value>
       <value compset="^SSP585EXT_CAM">ssp585ext</value>


### PR DESCRIPTION
### Description of changes:

Provide support for non-WACCM SSP534 compset, i.e. with `ndep_data_type=shr_stream`

sets `OCN_TRANSIENT=ssp534`, if compset longname starts with `SSP534_CAM`

adds namelist defaults for this `ocn_transisent` setting