### PR TITLE
dont call logging again

### DIFF
--- a/drivers/nuopc/ocn_comp_nuopc.F90
+++ b/drivers/nuopc/ocn_comp_nuopc.F90
@@ -353,15 +353,6 @@ contains
 
 !$  call omp_set_num_threads(nThreads)
 
-    ! reset shr logging to my log file
-    if (iam == 0) then
-       call set_component_logging(gcomp, .true., stdout, shrlogunit, rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    else
-       call set_component_logging(gcomp, .false., stdout, shrlogunit, rc)
-       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    end if
-
 #if (defined _MEMTRACE)
     if (iam == 0) then
        lbnum=1


### PR DESCRIPTION
### Description of changes:

Remove a redundant call to set_component_logging

### Testing: ERS_Vnuopc.T62_g37.G.cheyenne_gnu.pop-cice
 
Test case/suite:
Test status: bit for bit,

Fixes [POP2 Github issue #]

User interface (namelist or namelist defaults) changes?

