### PR TITLE
fixed ndep problem for pop in nuopc cap

### DIFF
--- a/drivers/nuopc/ocn_comp_nuopc.F90
+++ b/drivers/nuopc/ocn_comp_nuopc.F90
@@ -628,11 +628,9 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
     ldriver_has_atm_co2_diag = (itemType /= ESMF_STATEITEM_NOTFOUND)
 
-    call ESMF_StateGet(importState, 'Faxa_nhx', itemType1, rc=rc)
+    call ESMF_StateGet(importState, 'Faxa_ndep', itemType, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    call ESMF_StateGet(importState, 'Faxa_noy', itemType2, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    ldriver_has_ndep = ((itemType1 /= ESMF_STATEITEM_NOTFOUND) .or. (itemType2 /= ESMF_STATEITEM_NOTFOUND))
+    ldriver_has_ndep = (itemType /= ESMF_STATEITEM_NOTFOUND)
 
     if (ldriver_has_atm_co2_prog) then
        call named_field_register('ATM_CO2_PROG', ATM_CO2_PROG_nf_ind)


### PR DESCRIPTION
### Description of changes:

This only effects the nuopc cap. The problem was that separate ndep fields were advertised (Faxa_nhx, Faxa_nox) and what should have been advertised is a single field (Faxa_ndep) with 2 undistributed dimensions for nhx and noy.

### Testing:
 The following test were run and compared using cesm2_3_alpha03a and this pop PR code:
```
SMS_Vmct_Ln6.f19_g17.1850_CAM60%WCTS_CLM50%BGC-CROP_CICE_POP2%ECO%NDEP_MOSART_SGLC_WW3.cheyenne_intel.pop-default.validate
SMS_Vnuopc_Ln6.f19_g17.1850_CAM60%WCTS_CLM50%BGC-CROP_CICE_POP2%ECO%NDEP_MOSART_SGLC_WW3.cheyenne_intel.pop-default.validate
```
Test case/suite: Only test above was run
Test status: All other configurations should be bfbf

Fixes: None

User interface (namelist or namelist defaults) changes? No