### PR TITLE
Additional bug fixes for ndep and co2 from cam -> pop for nuopc cap

### DIFF
--- a/drivers/nuopc/ocn_comp_nuopc.F90
+++ b/drivers/nuopc/ocn_comp_nuopc.F90
@@ -584,9 +584,6 @@ contains
     type(ESMF_Clock)          :: clock
     type(ESMF_State)          :: importState
     type(ESMF_State)          :: exportState
-    type(ESMF_StateItem_Flag) :: itemType
-    type(ESMF_StateItem_Flag) :: itemType1
-    type(ESMF_StateItem_Flag) :: itemType2
     type(ESMF_TimeInterval)   :: timeStep        ! Model timestep
     type(ESMF_Time)           :: starttime
     character(CL)             :: cvalue
@@ -619,18 +616,6 @@ contains
 
     ! query the Component for its importState, exportState and clock
     call ESMF_GridCompGet(gcomp, importState=importState, exportState=exportState, clock=clock, rc=rc)
-
-    call ESMF_StateGet(importState, 'Sa_co2prog', itemType, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    ldriver_has_atm_co2_prog = (itemType /= ESMF_STATEITEM_NOTFOUND)
-
-    call ESMF_StateGet(importState, 'Sa_co2diag', itemType, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    ldriver_has_atm_co2_diag = (itemType /= ESMF_STATEITEM_NOTFOUND)
-
-    call ESMF_StateGet(importState, 'Faxa_ndep', itemType, rc=rc)
-    if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    ldriver_has_ndep = (itemType /= ESMF_STATEITEM_NOTFOUND)
 
     if (ldriver_has_atm_co2_prog) then
        call named_field_register('ATM_CO2_PROG', ATM_CO2_PROG_nf_ind)

--- a/drivers/nuopc/ocn_import_export.F90
+++ b/drivers/nuopc/ocn_import_export.F90
@@ -810,7 +810,7 @@ contains
                 frac_col_1pt(1)  = max(c0, min(c1, Sf_afrac(n)))
                 fracr_col_1pt(1) = max(c0, min(c1, Sf_afracr(n)))
                 qsw_fracr_col_1pt(1) = Foxx_swnet_afracr(n)
-                do ncol = 2,mcog_ncols ! same as ice_ncat
+                do ncol = 2,mcog_ncols ! mcog_ncols is the same as ice_ncat+1
                    frac_col_1pt(ncol)  = max(c0, min(c1, Si_ifrac_n(ncol-1,n)))
                    fracr_col_1pt(ncol) = max(c0, min(c1, Si_ifrac_n(ncol-1,n)))
                    qsw_fracr_col_1pt(ncol) = Fioi_swpen_ifrac_n(ncol-1,n)

--- a/drivers/nuopc/ocn_import_export.F90
+++ b/drivers/nuopc/ocn_import_export.F90
@@ -15,6 +15,7 @@ module ocn_import_export
   use shr_const_mod,         only: shr_const_spval
   use shr_string_mod,        only: shr_string_listGetNum, shr_string_listGetName
   use shr_mpi_mod,           only: shr_mpi_min, shr_mpi_max
+  use shr_ndep_mod,          only: shr_ndep_readnl
   use communicate,           only: my_task, master_task
   use ocn_communicator,      only: mpi_communicator_ocn
   use domain,                only: distrb_clinic, POP_haloClinic
@@ -37,6 +38,7 @@ module ocn_import_export
   use vmix_kpp,              only: KPP_HBLT      ! ocn -> wav, bounadry layer depth
   use grid,                  only: KMT, TAREA
   use nuopc_shr_methods,     only: chkerr
+  use ecosys_forcing_mod,    only: ldriver_has_ndep, ldriver_has_atm_co2_diag, ldriver_has_atm_co2_prog
   use constants
   use blocks
   use exit_mod
@@ -124,6 +126,10 @@ contains
     character(CS) :: cname
     integer       :: ice_ncat
     logical       :: flds_i2o_per_cat  ! .true. => select per ocn thickness category
+    logical       :: flds_co2a
+    logical       :: flds_co2b
+    logical       :: flds_co2c
+    integer       :: ndep_nflds
     character(len=*), parameter :: subname='(ocn_advertise_fields)'
     !-------------------------------------------------------------------------------
 
@@ -204,15 +210,53 @@ contains
 
     ! from atmosphere
     call fldlist_add(fldsToOcn_num, fldsToOcn, 'Sa_pslv')
-    call fldlist_add(fldsToOcn_num, fldsToOcn, 'Sa_co2prog')
-    call fldlist_add(fldsToOcn_num, fldsToOcn, 'Sa_co2diag')
     call fldlist_add(fldsToOcn_num, fldsToOcn, 'Faxa_lwdn')
     call fldlist_add(fldsToOcn_num, fldsToOcn, 'Faxa_snow')
     call fldlist_add(fldsToOcn_num, fldsToOcn, 'Faxa_rain')
     call fldlist_add(fldsToOcn_num, fldsToOcn, 'Faxa_bcph'  , ungridded_lbound=1, ungridded_ubound=3)
     call fldlist_add(fldsToOcn_num, fldsToOcn, 'Faxa_dstdry', ungridded_lbound=1, ungridded_ubound=4)
     call fldlist_add(fldsToOcn_num, fldsToOcn, 'Faxa_dstwet', ungridded_lbound=1, ungridded_ubound=4)
-    call fldlist_add(fldsToOcn_num, fldsToOcn, 'Faxa_ndep'  , ungridded_lbound=1, ungridded_ubound=2)
+
+    ! from atm co2 fields
+    call NUOPC_CompAttributeGet(gcomp, name='flds_co2a', value=cvalue, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    read(cvalue,*) flds_co2a
+    if (my_task == master_task) then
+       write(stdout,'(a)') trim(subname)//'flds_co2a = '// trim(cvalue)
+    end if
+
+    call NUOPC_CompAttributeGet(gcomp, name='flds_co2b', value=cvalue, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    read(cvalue,*) flds_co2b
+    if (my_task == master_task) then
+       write(stdout,'(a)') trim(subname)//'flds_co2b = '// trim(cvalue)
+    end if
+
+    call NUOPC_CompAttributeGet(gcomp, name='flds_co2c', value=cvalue, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    read(cvalue,*) flds_co2c
+    if (my_task == master_task) then
+       write(stdout,'(a)') trim(subname)//'flds_co2c = '// trim(cvalue)
+    end if
+
+    if (flds_co2a .or. flds_co2c) then
+       call fldlist_add(fldsToOcn_num, fldsToOcn, 'Sa_co2diag')
+       call fldlist_add(fldsToOcn_num, fldsToOcn, 'Sa_co2prog')
+       ldriver_has_atm_co2_prog = .true.
+       ldriver_has_atm_co2_diag = .true.
+    else
+       ldriver_has_atm_co2_prog = .false.
+       ldriver_has_atm_co2_diag = .false.
+    end if
+
+    ! Determine if will get nitrogen deposition from atm
+    call shr_ndep_readnl("drv_flds_in", ndep_nflds)
+    if (ndep_nflds > 0) then
+       ldriver_has_ndep = .true.
+       call fldlist_add(fldsToOcn_num, fldsToOcn, 'Faxa_ndep'  , ungridded_lbound=1, ungridded_ubound=2)
+    else
+       ldriver_has_ndep = .false.
+    end if
 
     ! optional per thickness category fields
     do n = 1,fldsToOcn_num
@@ -522,7 +566,7 @@ contains
     real (r8), pointer   :: fioi_melth(:)
     real (r8), pointer   :: fioi_salt(:)
     real (r8), pointer   :: fioi_swpen_ifrac_n(:,:)
-    real (r8)            :: frac_col_1pt(mcog_ncols) 
+    real (r8)            :: frac_col_1pt(mcog_ncols)
     real (r8)            :: fracr_col_1pt(mcog_ncols)
     real (r8)            :: qsw_fracr_col_1pt(mcog_ncols)
     ! from wave
@@ -604,7 +648,7 @@ contains
     ! 10m wind speed squared (m^2/s^2)
     call state_getfldptr(importState, 'So_duu10n', so_duu10n, rc=rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
- 
+
     n = 0
     do iblock = 1, nblocks_clinic
        this_block = get_block(blocks_clinic(iblock),iblock)
@@ -617,7 +661,7 @@ contains
              !  convert from W/m**2
              SHF_QSW(i,j,iblock) = foxx_swnet(n) * med2mod_areacor(n) * RCALCT(i,j,iblock)*hflux_factor
              ! convert from m**2/s**2 to cm**2/s**2
-             U10_SQR(i,j,iblock) = cmperm * cmperm * so_duu10n(n) * RCALCT(i,j,iblock) 
+             U10_SQR(i,j,iblock) = cmperm * cmperm * so_duu10n(n) * RCALCT(i,j,iblock)
          end do
        end do
     end do

--- a/drivers/nuopc/ocn_import_export.F90
+++ b/drivers/nuopc/ocn_import_export.F90
@@ -919,7 +919,7 @@ contains
           do j = this_block%jb,this_block%je
              do i = this_block%ib,this_block%ie
                 n = n+1
-                work1(:,:,:) = dataptr2d(n,1) * (1.0e-1_r8 * (c1/14.0_r8) * 1.0e9_r8) * med2mod_areacor(n)
+                work1(i,j,iblock) = dataptr2d(1,n) * (1.0e-1_r8 * (c1/14.0_r8) * 1.0e9_r8) * med2mod_areacor(n)
              end do
           end do
        end do
@@ -937,7 +937,7 @@ contains
           do j = this_block%jb,this_block%je
              do i = this_block%ib,this_block%ie
                 n = n+1
-                work1(:,:,:) = dataptr2d(n,2) * (1.0e-1_r8 * (c1/14.0_r8) * 1.0e9_r8) * med2mod_areacor(n)
+                work1(i,j,iblock) = dataptr2d(2,n) * (1.0e-1_r8 * (c1/14.0_r8) * 1.0e9_r8) * med2mod_areacor(n)
              end do
           end do
        end do

--- a/drivers/nuopc/ocn_import_export.F90
+++ b/drivers/nuopc/ocn_import_export.F90
@@ -312,9 +312,7 @@ contains
     real(r8), pointer     :: lonModel(:), lonMesh(:)
     real(r8)              :: diff_lon
     real(r8)              :: diff_lat
-    !DEBUG
     type(ESMF_StateItem_Flag) :: itemflag
-    !DEBUG
     character(len=*), parameter :: subname='(ocn_import_export:realize_fields)'
     !---------------------------------------------------------------------------
 
@@ -462,12 +460,10 @@ contains
     deallocate(model_areas)
     deallocate(mesh_areas)
 
-    !DEBUG
     call ESMF_StateGet(importState, 'Faxa_ndep', itemFlag, rc=rc)
     if (itemFlag /= ESMF_STATEITEM_NOTFOUND) then
        call ESMF_LogWrite(subname//' Faxa_ndep is in import state', ESMF_LOGMSG_INFO)
     end if
-    !DEBUG
 
   end subroutine ocn_realize_fields
 


### PR DESCRIPTION
### Description of changes:
Additional bug fixes for ndep and co2 from cam -> pop for nuopc cap only

### Testing:
 SMS_Vmct_Ln6.f19_g17.1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_SGLC_WW3_BGC%BPRP.cheyenne_intel
 SMS_Vnuopc_Ln6.f19_g17.1850_CAM60_CLM50%BGC-CROP_CICE_POP2%ECO_MOSART_SGLC_WW3_BGC%BPRP.cheyenne_intel
SMS_Vmct_Ld5.f19_g17.1850_CAM60%WCTS_CLM50%BGC-CROP_CICE_POP2%ECO%NDEP_MOSART_SGLC_WW3.cheyenne_intel.pop-default
SMS_Vnuopc_Ld5.f19_g17.1850_CAM60%WCTS_CLM50%BGC-CROP_CICE_POP2%ECO%NDEP_MOSART_SGLC_WW3.cheyenne_intel.pop-default

Test case/suite: Just ran above tests

Test status: Should not effect any other tests

Fixes:

User interface (namelist or namelist defaults) changes? None

