### PR TITLE
Initialize dataptr2(:)

### DIFF
--- a/drivers/nuopc/ocn_import_export.F90
+++ b/drivers/nuopc/ocn_import_export.F90
@@ -1309,6 +1309,7 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     dataptr1(:) = shr_const_spval
+    dataptr2(:) = shr_const_spval
     n = 0
     do iblock = 1, nblocks_clinic
        this_block = get_block(blocks_clinic(iblock),iblock)


### PR DESCRIPTION
### Description of changes:

Added a single line to `drivers/nuopc/ocn_import_export.F90` to make sure `So_dhdy` is initialized to `_FillValue` before passing it to the coupler

[ Description of the changes in this Pull Request. It should be enough
information for someone not following this development to understand.]

### Testing:
 
Test case/suite:

Ran `SMS_Ld1_P136_D.T62_g17.C.cheyenne_intel.pop-144blocks_320x384_spacecurve` out of the box, verified that `ncview` balked at displaying `ocnImp_So_dhdy` with error

```
calculating min and maxes for ocnImp_So_dhdx.
netcdf_fi_get_data: error on nc_get_vara_float call
cdfid=65536   variable=ocnImp_So_dhdy
start, count:
[0]: 0  1
[1]: 0  384
[2]: 0  320
```

With this patch, the field can now be displayed (has missing values instead of extremely large values where land blocks were eliminated)

Test status: should allow previously failing `spacecurve` tests to pass, but rest of tests are bfb

Fixes [POP2 Github issue #] N/A (I didn't open a POP issue because I was expecting to trace this to either the coupler, PIO, or `cprnc`)

User interface (namelist or namelist defaults) changes? N/A

