### PR TITLE
clean up nuopc cap, reduce output to cesm.log file

### DIFF
--- a/drivers/nuopc/ocn_import_export.F90
+++ b/drivers/nuopc/ocn_import_export.F90
@@ -34,6 +34,7 @@ module ocn_import_export
   use ice,                   only: QFLUX, QICE, AQICE, tlast_ice
   use global_reductions,     only: global_sum_prod
   use io_tools,              only: document
+  use io_types,              only: stdout
   use named_field_mod,       only: named_field_register, named_field_get_index, named_field_set, named_field_get
   use vmix_kpp,              only: KPP_HBLT      ! ocn -> wav, bounadry layer depth
   use grid,                  only: KMT, TAREA

--- a/source/POP_SolversMod.F90
+++ b/source/POP_SolversMod.F90
@@ -2499,9 +2499,10 @@
        endif 
      end do 
    end do 
+#ifdef DEBUG
    write(POP_stdout,'(a8,I5,a15,I5,a15,I5)') 'PROC',POP_myTask, & 
                     ' EVP blocks :',nb*mb, ' land blocks :', sum(landIndx)
-
+#endif
   end subroutine EvpPre
   
   subroutine ExplicitBlockEvpPre(cc,ne,rinv,n,m)

--- a/source/damping.F90
+++ b/source/damping.F90
@@ -21,7 +21,7 @@
    use communicate,     only : my_task, master_task
    use broadcast,       only : broadcast_scalar
    use exit_mod,        only : exit_POP, sigAbort
-   use io_types,        only : nml_in, nml_filename
+   use io_types,        only : nml_in, nml_filename, stdout
 #ifdef CCSMCOUPLED
    use shr_sys_mod, only: shr_sys_abort
 #endif
@@ -74,7 +74,7 @@
          read(nml_in, nml=damping_nml,iostat=nml_error)
       end do
       if (nml_error == 0) close(nml_in)
-      print*, "Done setting default values!"
+      write(stdout,*) "Done setting default values! (damping.F90)"
     end if
 
 !!!! BROADCAST NAMELIST OPTIONS OUT

--- a/source/overflows.F90
+++ b/source/overflows.F90
@@ -1237,8 +1237,12 @@
                    do m=1,ovf(n)%num_kmt
                       if( ovf(n)%loc_kmt(m)%i.eq.this_block%i_glob(i).and.&
                           ovf(n)%loc_kmt(m)%j.eq.this_block%j_glob(j) ) then
-                         write(stdout,100) KMT(i,j,iblock),ovf(n)%loc_kmt(m)%i, &
-                                ovf(n)%loc_kmt(m)%j,ovf(n)%loc_kmt(m)%knew
+#ifndef DEBUG
+                         if (my_task == master_task) &
+#endif
+                            write(stdout,100) KMT(i,j,iblock),ovf(n)%loc_kmt(m)%i, &
+                                 ovf(n)%loc_kmt(m)%j,ovf(n)%loc_kmt(m)%knew
+
                          100 format(' init_overflows_kmt: KMT = ',i5,&
                                     ' at global (i,j) = ',2(i5,1x),&
                                     ' changed to ',i5)
@@ -1323,6 +1327,9 @@
                   if( ovf(n)%reg_inf%imin  .le. this_block%i_glob(i) .and. &
                       this_block%i_glob(i) .le. ovf(n)%reg_inf%imax ) then
                          ovf(n)%mask_reg%inf(i,j,iblock) = c1
+#ifndef DEBUG
+                         if (my_task == master_task) &
+#endif
                          write(stdout,30) ovf(n)%name,this_block%i_glob(i), &
                                            this_block%j_glob(j)
                          30 format(' Overflow: ',a24, &
@@ -1338,6 +1345,9 @@
                   if( ovf(n)%reg_src%imin  .le. this_block%i_glob(i) .and. &
                       this_block%i_glob(i) .le. ovf(n)%reg_src%imax ) then
                          ovf(n)%mask_reg%src(i,j,iblock) = c1
+#ifndef DEBUG
+                         if (my_task == master_task) &
+#endif
                          write(stdout,31) ovf(n)%name,this_block%i_glob(i), &
                                            this_block%j_glob(j)
                          31 format(' Overflow: ',a24, &
@@ -1353,6 +1363,9 @@
                   if( ovf(n)%adj_src%imin  .le. this_block%i_glob(i) .and. &
                       this_block%i_glob(i) .le. ovf(n)%adj_src%imax ) then
                          ovf(n)%mask_adj%src(i,j,iblock) = c1
+#ifndef DEBUG
+                         if (my_task == master_task) &
+#endif
                          write(stdout,32) ovf(n)%name,this_block%i_glob(i), &
                                            this_block%j_glob(j)
                          32 format(' Overflow: ',a24, &
@@ -1368,6 +1381,9 @@
                   if( ovf(n)%reg_ent%imin  .le. this_block%i_glob(i) .and. &
                       this_block%i_glob(i) .le. ovf(n)%reg_ent%imax ) then
                          ovf(n)%mask_reg%ent(i,j,iblock) = c1
+#ifndef DEBUG
+                         if (my_task == master_task) &
+#endif
                          write(stdout,33) ovf(n)%name,this_block%i_glob(i), &
                                            this_block%j_glob(j)
                          33 format(' Overflow: ',a24, &
@@ -1383,6 +1399,9 @@
                   if( ovf(n)%adj_ent%imin  .le. this_block%i_glob(i) .and. &
                       this_block%i_glob(i) .le. ovf(n)%adj_ent%imax ) then
                          ovf(n)%mask_adj%ent(i,j,iblock) = c1
+#ifndef DEBUG
+                         if (my_task == master_task) &
+#endif
                          write(stdout,34) ovf(n)%name,this_block%i_glob(i), &
                                            this_block%j_glob(j)
                          34 format(' Overflow: ',a24, &
@@ -1401,6 +1420,9 @@
                      if( ovf(n)%adj_prd(m)%imin  .le. this_block%i_glob(i) .and. &
                          this_block%i_glob(i) .le. ovf(n)%adj_prd(m)%imax ) then
                             ovf(n)%mask_adj%prd(i,j,iblock,m) = c1
+#ifndef DEBUG
+                         if (my_task == master_task) &
+#endif
                             write(stdout,35) ovf(n)%name,this_block%i_glob(i), &
                                               this_block%j_glob(j)
                             35 format(' Overflow: ',a24, &

--- a/source/tidal_mixing.F90
+++ b/source/tidal_mixing.F90
@@ -970,13 +970,13 @@
      call exit_POP (SigAbort, 'ERROR  ALL REGION_BOX2D_G values are zero')
    endif
    endif ! master_task
-
+#ifdef DEBUG
    if (any(REGION_BOX2D .ne. 0)) then
      write(stdout,*) my_task, ': (init_tidal_mixing1) not all REGION_BOX2D values are zero'
    else
      write(stdout,*) my_task, ': (init_tidal_mixing1)     ALL REGION_BOX2D values are zero'
    endif
-
+#endif
  !... create 3D local tidal-region box mask
    do iblock = 1,nblocks_clinic
       do ii=1,num_tidal_min_regions
@@ -1009,6 +1009,9 @@
                           grid_loc='3111',                        &
                           coordinates  ='TLONG TLAT z_w time'     ) 
 
+#ifndef DEBUG
+   if (my_task == master_task) then
+#endif
    do iblock = 1,nblocks_clinic
      this_block = get_block(blocks_clinic(iblock),iblock)
      do ii=1,num_tidal_min_regions
@@ -1027,9 +1030,15 @@
       enddo ! k
      enddo ! ii
    enddo ! iblock
+#ifndef DEBUG
+  endif
+#endif
 1212 format(1x, a, a, 6i4, 1x, 2F10.2)
 1213 format(1x, a, 6i3)
-write(stdout,*) ' after REGION_BOX3D print test'
+#ifndef DEBUG
+            if (my_task == master_task) &
+#endif
+                 write(stdout,*) ' after REGION_BOX3D print test'
 
    deallocate (REGION_BOX2D_G, REGION_BOX2D)
    deallocate (TLAT_G, TLON_G)


### PR DESCRIPTION
### Description of changes:

Cleanup output to stdout.  This PR is intended to reduce the amount of data written to the cesm.log in 
production mode.  When DEBUG is defined all output is retained. 

### Testing:
Tested by hand using
   ERS_D.f19_g17.B1850.cheyenne_intel.allactive-defaultio
Test case/suite: 
Test status: bit for bit

Fixes [POP2 Github issue #]

User interface (namelist or namelist defaults) changes?  NONE

