### PR TITLE
CESM 2.1.z: Add derecho support, remove cheyenne support

### DIFF
--- a/BranchChangeLog
+++ b/BranchChangeLog
@@ -1,5 +1,18 @@
 ===============================================================
 Tag Creator: mlevy
+Developers:  mlevy
+Tag Date:    21 Nov 2023
+Tag Name:    pop2_cesm2_1_rel_n15
+Tag Summary: add support for derecho, remove support for cheyenne
+
+Testing: ran a series of smoke tests to ensure PE layouts are reasonable
+
+Changes to be committed:
+	modified:   bld/generate_pop_decomp.xml
+	modified:   cime_config/config_pes.xml
+	modified:   cime_config/testdefs/testlist_pop.xml
+===============================================================
+Tag Creator: mlevy
 Developers:  klindsay
 Tag Date:    25 Feb 2021
 Tag Name:    pop2_cesm2_1_rel_n14

--- a/bld/generate_pop_decomp.xml
+++ b/bld/generate_pop_decomp.xml
@@ -184,6 +184,15 @@
     <decomptype>cartesian</decomptype>
   </decomp>
 
+  <decomp nproc="128" res="gx3v7" >
+    <maxblocks >1</maxblocks>
+    <bsize_x   >13</bsize_x>
+    <bsize_y   >8</bsize_y>
+    <nx_blocks >8</nx_blocks>
+    <ny_blocks >16</ny_blocks>
+    <decomptype>cartesian</decomptype>
+  </decomp>
+
 <!-- ====================================================================== -->
 
   <!-- gx1v[67] resolution -->
@@ -771,6 +780,48 @@
     <maxblocks >1</maxblocks>
     <bsize_x   >25</bsize_x>
     <bsize_y   >32</bsize_y>
+    <decomptype>spacecurve</decomptype>
+  </decomp>
+
+  <decomp nproc="12276" res="tx0.1v3" >
+    <maxblocks >1</maxblocks>
+    <bsize_x   >24</bsize_x>
+    <bsize_y   >20</bsize_y>
+    <decomptype>spacecurve</decomptype>
+  </decomp>
+
+  <decomp nproc="14666" res="tx0.1v3" >
+    <maxblocks >1</maxblocks>
+    <bsize_x   >20</bsize_x>
+    <bsize_y   >20</bsize_y>
+    <decomptype>spacecurve</decomptype>
+  </decomp>
+
+  <decomp nproc="20184" res="tx0.1v3" >
+    <maxblocks >1</maxblocks>
+    <bsize_x   >18</bsize_x>
+    <bsize_y   >16</bsize_y>
+    <decomptype>spacecurve</decomptype>
+  </decomp>
+
+  <decomp nproc="22626" res="tx0.1v3" >
+    <maxblocks >1</maxblocks>
+    <bsize_x   >16</bsize_x>
+    <bsize_y   >16</bsize_y>
+    <decomptype>spacecurve</decomptype>
+  </decomp>
+
+  <decomp nproc="25654" res="tx0.1v3" >
+    <maxblocks >1</maxblocks>
+    <bsize_x   >15</bsize_x>
+    <bsize_y   >15</bsize_y>
+    <decomptype>spacecurve</decomptype>
+  </decomp>
+
+  <decomp nproc="39661" res="tx0.1v3" >
+    <maxblocks >1</maxblocks>
+    <bsize_x   >12</bsize_x>
+    <bsize_y   >12</bsize_y>
     <decomptype>spacecurve</decomptype>
   </decomp>
 

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -50,22 +50,22 @@
   <!-- Defaults for gx3v7 resolution -->
   <grid name="oi%gx3v7">
 
-    <!-- gx3v7 resolution on cheyenne  -->
-    <mach name="cheyenne">
+    <!-- gx3v7 resolution on derecho  -->
+    <mach name="derecho">
 
-      <!-- C and C+ECO (e.g., C1850ECO) with gx3v7 on cheyenne:
-           all components share 72x1 -->
+      <!-- C and C+ECO (e.g., C1850ECO) with gx3v7 on derecho:
+           all components share 128x1 -->
       <pes pesize="any" compset="_DATM.*_DICE.*_POP2">
-        <comment>C or C+ECO (e.g., C1850ECO); gx3v7 resolution on cheyenne</comment>
+        <comment>C or C+ECO (e.g., C1850ECO); gx3v7 resolution on derecho</comment>
         <ntasks>
-          <ntasks_ocn>72</ntasks_ocn>
-          <ntasks_ice>72</ntasks_ice>
-          <ntasks_cpl>72</ntasks_cpl>
-          <ntasks_wav>72</ntasks_wav>
-          <ntasks_atm>72</ntasks_atm>
-          <ntasks_glc>72</ntasks_glc>
-          <ntasks_lnd>72</ntasks_lnd>
-          <ntasks_rof>72</ntasks_rof>
+          <ntasks_ocn>128</ntasks_ocn>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_cpl>128</ntasks_cpl>
+          <ntasks_wav>128</ntasks_wav>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_glc>128</ntasks_glc>
+          <ntasks_lnd>128</ntasks_lnd>
+          <ntasks_rof>128</ntasks_rof>
         </ntasks>
         <nthrds>
           <nthrds_ocn>1</nthrds_ocn>
@@ -89,21 +89,20 @@
         </rootpe>
       </pes>
 
-      <!-- G with gx3v7 on cheyenne:
-           POP gets 72x1
-           CICE gets 36x1
-           all other components share 36x1 -->
-      <pes pesize="any" compset="_DATM.*_CICE.*_POP2[^%]">
-        <comment>G; gx3v7 resolution on cheyenne</comment>
+      <!-- G & GECO with gx3v7 on derecho:
+           POP gets 128x1
+           all other components share 128x1 -->
+      <pes pesize="any" compset="_DATM.*_CICE.*_POP2">
+        <comment>G; gx3v7 resolution on derecho</comment>
         <ntasks>
-          <ntasks_ocn>72</ntasks_ocn>
-          <ntasks_ice>36</ntasks_ice>
-          <ntasks_cpl>36</ntasks_cpl>
-          <ntasks_wav>36</ntasks_wav>
-          <ntasks_atm>36</ntasks_atm>
-          <ntasks_glc>36</ntasks_glc>
-          <ntasks_lnd>36</ntasks_lnd>
-          <ntasks_rof>36</ntasks_rof>
+          <ntasks_ocn>128</ntasks_ocn>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_cpl>128</ntasks_cpl>
+          <ntasks_wav>128</ntasks_wav>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_glc>128</ntasks_glc>
+          <ntasks_lnd>128</ntasks_lnd>
+          <ntasks_rof>128</ntasks_rof>
         </ntasks>
         <nthrds>
           <nthrds_ocn>1</nthrds_ocn>
@@ -116,44 +115,7 @@
           <nthrds_rof>1</nthrds_rof>
         </nthrds>
         <rootpe>
-          <rootpe_ocn>72</rootpe_ocn>
-          <rootpe_ice>36</rootpe_ice>
-          <rootpe_cpl>36</rootpe_cpl>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-        </rootpe>
-      </pes>
-
-      <!-- G+ECO (e.g., G1850ECO) with gx3v7 on cheyenne:
-           POP gets 72x1
-           all other components share 36x1 -->
-      <pes pesize="any" compset="_DATM.*_CICE.*_POP2%ECO">
-        <comment>G+ECO (e.g., G1850ECO); gx3v7 resolution on cheyenne</comment>
-        <ntasks>
-          <ntasks_ocn>72</ntasks_ocn>
-          <ntasks_ice>36</ntasks_ice>
-          <ntasks_cpl>36</ntasks_cpl>
-          <ntasks_wav>36</ntasks_wav>
-          <ntasks_atm>36</ntasks_atm>
-          <ntasks_glc>36</ntasks_glc>
-          <ntasks_lnd>36</ntasks_lnd>
-          <ntasks_rof>36</ntasks_rof>
-        </ntasks>
-        <nthrds>
-          <nthrds_ocn>1</nthrds_ocn>
-          <nthrds_ice>1</nthrds_ice>
-          <nthrds_cpl>1</nthrds_cpl>
-          <nthrds_wav>1</nthrds_wav>
-          <nthrds_atm>1</nthrds_atm>
-          <nthrds_glc>1</nthrds_glc>
-          <nthrds_lnd>1</nthrds_lnd>
-          <nthrds_rof>1</nthrds_rof>
-        </nthrds>
-        <rootpe>
-          <rootpe_ocn>36</rootpe_ocn>
+          <rootpe_ocn>128</rootpe_ocn>
           <rootpe_ice>0</rootpe_ice>
           <rootpe_cpl>0</rootpe_cpl>
           <rootpe_wav>0</rootpe_wav>
@@ -209,23 +171,23 @@
   <!-- Defaults for gx1v6, gx1v7, or tx1v1 resolution -->
   <grid name="oi%gx1v[67]|oi%tx1v1">
 
-    <!-- gx1v6, gx1v7, or tx1v1 resolution on cheyenne  -->
-    <mach name="cheyenne">
+    <!-- gx1v6, gx1v7, or tx1v1 resolution on derecho  -->
+    <mach name="derecho">
 
-      <!-- C compset, gx1v6, gx1v7, or tx1v1 on cheyenne:
-           POP gets 144x1
-           all other components share 36x1 -->
-      <pes pesize="any" compset="_DATM.*_DICE.*_POP2[^%]">
-        <comment>C; gx1v6, gx1v7, or tx1v1 resolution on cheyenne</comment>
+      <!-- C or G compset with gx1v6, gx1v7, or tx1v1 on derecho:
+           POP gets 128x1
+           all other components share 128x1 -->
+      <pes pesize="any" compset="_DATM.*_POP2[^%]">
+        <comment>C; gx1v6, gx1v7, or tx1v1 resolution on derecho</comment>
         <ntasks>
-          <ntasks_ocn>144</ntasks_ocn>
-          <ntasks_ice>36</ntasks_ice>
-          <ntasks_cpl>36</ntasks_cpl>
-          <ntasks_wav>36</ntasks_wav>
-          <ntasks_atm>36</ntasks_atm>
-          <ntasks_glc>36</ntasks_glc>
-          <ntasks_lnd>36</ntasks_lnd>
-          <ntasks_rof>36</ntasks_rof>
+          <ntasks_ocn>128</ntasks_ocn>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_cpl>128</ntasks_cpl>
+          <ntasks_wav>128</ntasks_wav>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_glc>128</ntasks_glc>
+          <ntasks_lnd>128</ntasks_lnd>
+          <ntasks_rof>128</ntasks_rof>
         </ntasks>
         <nthrds>
           <nthrds_ocn>1</nthrds_ocn>
@@ -238,7 +200,7 @@
           <nthrds_rof>1</nthrds_rof>
         </nthrds>
         <rootpe>
-          <rootpe_ocn>36</rootpe_ocn>
+          <rootpe_ocn>128</rootpe_ocn>
           <rootpe_ice>0</rootpe_ice>
           <rootpe_cpl>0</rootpe_cpl>
           <rootpe_wav>0</rootpe_wav>
@@ -249,57 +211,21 @@
         </rootpe>
       </pes>
 
-      <!-- C+ECO (e.g., C1850ECO) compset with gx1v6, gx1v7, or tx1v1 resolution on cheyenne
-           POP gets 216x2
-           all other components share 18x2 -->
-      <pes pesize="any" compset="_DATM.*_DICE.*_POP2%ECO">
-        <comment>C+ECO (e.g., C1850ECO); gx1v6, gx1v7, or tx1v1 resolution on cheyenne</comment>
+      <!-- C+ECO (e.g., C1850ECO) or G+ECO (e.g., G1850ECO) compset
+           with gx1v6, gx1v7, or tx1v1 resolution on derecho
+           POP gets 384x1
+           all other components share 128x1 -->
+      <pes pesize="any" compset="_DATM.*_POP2%ECO">
+        <comment>C+ECO (e.g., C1850ECO); gx1v6, gx1v7, or tx1v1 resolution on derecho</comment>
         <ntasks>
-          <ntasks_ocn>216</ntasks_ocn>
-          <ntasks_ice>18</ntasks_ice>
-          <ntasks_cpl>18</ntasks_cpl>
-          <ntasks_wav>18</ntasks_wav>
-          <ntasks_atm>18</ntasks_atm>
-          <ntasks_glc>18</ntasks_glc>
-          <ntasks_lnd>18</ntasks_lnd>
-          <ntasks_rof>18</ntasks_rof>
-        </ntasks>
-        <nthrds>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_cpl>2</nthrds_cpl>
-          <nthrds_wav>2</nthrds_wav>
-          <nthrds_atm>2</nthrds_atm>
-          <nthrds_glc>2</nthrds_glc>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-        </nthrds>
-        <rootpe>
-          <rootpe_ocn>18</rootpe_ocn>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_cpl>0</rootpe_cpl>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-        </rootpe>
-      </pes>
-
-      <!-- G compset, gx1v6, gx1v7, or tx1v1 on cheyenne:
-           POP gets 144x1
-           all other components share 72x1 -->
-      <pes pesize="any" compset="_DATM.*_CICE.*_POP2[^%]">
-        <comment>G; gx1v6, gx1v7, or tx1v1 resolution on cheyenne</comment>
-        <ntasks>
-          <ntasks_ocn>144</ntasks_ocn>
-          <ntasks_ice>72</ntasks_ice>
-          <ntasks_cpl>72</ntasks_cpl>
-          <ntasks_wav>72</ntasks_wav>
-          <ntasks_atm>72</ntasks_atm>
-          <ntasks_glc>72</ntasks_glc>
-          <ntasks_lnd>72</ntasks_lnd>
-          <ntasks_rof>72</ntasks_rof>
+          <ntasks_ocn>384</ntasks_ocn>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_cpl>128</ntasks_cpl>
+          <ntasks_wav>128</ntasks_wav>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_glc>128</ntasks_glc>
+          <ntasks_lnd>128</ntasks_lnd>
+          <ntasks_rof>128</ntasks_rof>
         </ntasks>
         <nthrds>
           <nthrds_ocn>1</nthrds_ocn>
@@ -312,44 +238,7 @@
           <nthrds_rof>1</nthrds_rof>
         </nthrds>
         <rootpe>
-          <rootpe_ocn>72</rootpe_ocn>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_cpl>0</rootpe_cpl>
-          <rootpe_wav>0</rootpe_wav>
-          <rootpe_atm>0</rootpe_atm>
-          <rootpe_glc>0</rootpe_glc>
-          <rootpe_lnd>0</rootpe_lnd>
-          <rootpe_rof>0</rootpe_rof>
-        </rootpe>
-      </pes>
-
-      <!-- G+ECO (e.g., G1850ECO) compset, gx1v6, gx1v7, or tx1v1 resolution on cheyenne:
-           POP gets 216x2
-           all other components share 36x2 -->
-      <pes pesize="any" compset="_DATM.*_CICE.*_POP2%ECO">
-        <comment>G+ECO (e.g., G1850ECO); gx1v6, gx1v7, or tx1v1 resolution on cheyenne</comment>
-        <ntasks>
-          <ntasks_ocn>216</ntasks_ocn>
-          <ntasks_ice>36</ntasks_ice>
-          <ntasks_cpl>36</ntasks_cpl>
-          <ntasks_wav>36</ntasks_wav>
-          <ntasks_atm>36</ntasks_atm>
-          <ntasks_glc>36</ntasks_glc>
-          <ntasks_lnd>36</ntasks_lnd>
-          <ntasks_rof>36</ntasks_rof>
-        </ntasks>
-        <nthrds>
-          <nthrds_ocn>2</nthrds_ocn>
-          <nthrds_ice>2</nthrds_ice>
-          <nthrds_cpl>2</nthrds_cpl>
-          <nthrds_wav>2</nthrds_wav>
-          <nthrds_atm>2</nthrds_atm>
-          <nthrds_glc>2</nthrds_glc>
-          <nthrds_lnd>2</nthrds_lnd>
-          <nthrds_rof>2</nthrds_rof>
-        </nthrds>
-        <rootpe>
-          <rootpe_ocn>36</rootpe_ocn>
+          <rootpe_ocn>128</rootpe_ocn>
           <rootpe_ice>0</rootpe_ice>
           <rootpe_cpl>0</rootpe_cpl>
           <rootpe_wav>0</rootpe_wav>
@@ -361,7 +250,7 @@
       </pes>
     </mach>
 
-    <!-- gx1v6, gx1v7, or tx1v1 resolution on cheyenne  -->
+    <!-- gx1v6, gx1v7, or tx1v1 resolution on hobart  -->
     <mach name="hobart">
 
       <!-- C, C+ECO (e.g., C1850ECO) with gx1v6, gx1v7, or tx1v1 on hobart:
@@ -441,7 +330,7 @@
   </grid>
 
   <!-- Defaults for tx0.1v2 -->
-  <!-- FIXME: update this for cheyenne -->
+  <!-- FIXME: update this for derecho -->
   <grid name="oi%tx0.1v2">
 
     <mach name="any">
@@ -517,7 +406,6 @@
   </grid>
 
   <!-- Defaults for tx0.1v3 -->
-  <!-- FIXME: update this for cheyenne -->
   <grid name="oi%tx0.1v3">
 
     <mach name="any">
@@ -591,19 +479,22 @@
       </pes>
     </mach>
 
-    <mach name="cheyenne">
+    <mach name="derecho">
 
+      <!-- C or C+ECO compset, tx0.1v3 on derecho:
+           POP gets 22626x1
+           all other components share 128x1 -->
       <pes pesize="any" compset="_DATM.*_DICE.*_POP2">
         <comment>none</comment>
         <ntasks>
-          <ntasks_atm>72</ntasks_atm>
-          <ntasks_rof>72</ntasks_rof>
-          <ntasks_cpl>72</ntasks_cpl>
-          <ntasks_ice>72</ntasks_ice>
-          <ntasks_ocn>2208</ntasks_ocn>
-          <ntasks_lnd>72</ntasks_lnd>
-          <ntasks_wav>72</ntasks_wav>
-          <ntasks_glc>72</ntasks_glc>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_rof>128</ntasks_rof>
+          <ntasks_cpl>128</ntasks_cpl>
+          <ntasks_ice>128</ntasks_ice>
+          <ntasks_ocn>22626</ntasks_ocn>
+          <ntasks_lnd>128</ntasks_lnd>
+          <ntasks_wav>128</ntasks_wav>
+          <ntasks_glc>128</ntasks_glc>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
@@ -620,24 +511,28 @@
           <rootpe_rof>0</rootpe_rof>
           <rootpe_cpl>0</rootpe_cpl>
           <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>72</rootpe_ocn>
+          <rootpe_ocn>128</rootpe_ocn>
           <rootpe_lnd>0</rootpe_lnd>
           <rootpe_wav>0</rootpe_wav>
           <rootpe_glc>0</rootpe_glc>
         </rootpe>
       </pes>
 
+      <!-- G or G+ECO compset, tx0.1v3 on derecho:
+           POP gets 22626x1
+           CICE gets 768x1
+           all other components share 128x1 -->
       <pes pesize="any" compset="_DATM.*_CICE.*_POP2">
         <comment>none</comment>
         <ntasks>
-          <ntasks_atm>72</ntasks_atm>
-          <ntasks_lnd>72</ntasks_lnd>
-          <ntasks_rof>72</ntasks_rof>
-          <ntasks_ice>828</ntasks_ice>
-          <ntasks_ocn>2208</ntasks_ocn>
-          <ntasks_glc>72</ntasks_glc>
-          <ntasks_wav>72</ntasks_wav>
-          <ntasks_cpl>828</ntasks_cpl>
+          <ntasks_atm>128</ntasks_atm>
+          <ntasks_lnd>128</ntasks_lnd>
+          <ntasks_rof>128</ntasks_rof>
+          <ntasks_ice>768</ntasks_ice>
+          <ntasks_ocn>22626</ntasks_ocn>
+          <ntasks_glc>128</ntasks_glc>
+          <ntasks_wav>128</ntasks_wav>
+          <ntasks_cpl>128</ntasks_cpl>
         </ntasks>
         <nthrds>
           <nthrds_atm>1</nthrds_atm>
@@ -653,8 +548,8 @@
           <rootpe_atm>0</rootpe_atm>
           <rootpe_lnd>0</rootpe_lnd>
           <rootpe_rof>0</rootpe_rof>
-          <rootpe_ice>0</rootpe_ice>
-          <rootpe_ocn>828</rootpe_ocn>
+          <rootpe_ice>128</rootpe_ice>
+          <rootpe_ocn>896</rootpe_ocn>
           <rootpe_glc>0</rootpe_glc>
           <rootpe_wav>0</rootpe_wav>
           <rootpe_cpl>0</rootpe_cpl>

--- a/cime_config/testdefs/testlist_pop.xml
+++ b/cime_config/testdefs/testlist_pop.xml
@@ -2,35 +2,35 @@
 <testlist version="2.0">
   <test name="ERI" grid="T62_g16" compset="C1850ECO" testmods="pop/ecosys">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
     </machines>
   </test>
   <test name="ERI" grid="T62_g17" compset="C1850ECO" testmods="pop/ecosys">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERI" grid="T62_g17" compset="C1850ECO" testmods="pop/ciso">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
     </machines>
   </test>
   <test name="ERI" grid="T62_g37" compset="G" testmods="pop/cice">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
     </machines>
   </test>
   <test name="ERS" grid="T62_s11" compset="G" testmods="pop/default">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_tripole"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_tripole"/>
     </machines>
   </test>
   <test name="ERS" grid="T62_g16" compset="C" testmods="pop/default">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_rasm"/>
-      <machine name="cheyenne" compiler="intel" category="aux_science"/>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="derecho" compiler="intel" category="aux_rasm"/>
+      <machine name="derecho" compiler="intel" category="aux_science"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
       <machine name="eastwind" compiler="pgi" category="aux_rasm"/>
       <machine name="evergreen" compiler="intel" category="aux_rasm"/>
       <machine name="olympus" compiler="pgi" category="aux_rasm"/>
@@ -38,12 +38,12 @@
   </test>
   <test name="ERS" grid="T62_g17" compset="C" testmods="pop/default">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS" grid="T62_g17" compset="C" testmods="pop/cfc_sf6">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS" grid="T62_s11" compset="C" testmods="pop/default">
@@ -53,37 +53,35 @@
   </test>
   <test name="ERS" grid="T62_g16" compset="C1850ECO" testmods="pop/ecosys">
     <machines>
-      <machine name="cheyenne" compiler="gnu" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="pgi" category="prebeta"/>
+      <machine name="derecho" compiler="intel" category="prebeta"/>
       <machine name="hobart" compiler="intel" category="prebeta"/>
       <machine name="hobart" compiler="pgi" category="prebeta"/>
     </machines>
   </test>
   <test name="ERS" grid="T62_g17" compset="C1850ECO" testmods="pop/ecosys_ocn_transient_1850_2000">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
     </machines>
   </test>
   <test name="ERS" grid="T62_g37" compset="C1850ECO" testmods="pop/ecosys">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS" grid="T62_g37" compset="C1850ECO" testmods="pop/ciso_abio_dic_dic14">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
     </machines>
   </test>
   <test name="ERS" grid="T62_g37" compset="C1850ECO" testmods="pop/ciso_transient">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
     </machines>
   </test>
   <test name="ERS" grid="T62_g37" compset="C1850ECO" testmods="pop/ciso_transient_abio_dic_dic14_transient">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
     </machines>
   </test>
   <test name="ERS" grid="T62_g16" compset="G" testmods="pop/cice">
@@ -94,11 +92,7 @@
   </test>
   <test name="ERS" grid="T62_g37" compset="G" testmods="pop/cice">
     <machines>
-      <machine name="cheyenne" compiler="gnu" category="aux_pop"/>
-      <machine name="cheyenne" compiler="gnu" category="prealpha"/>
-      <machine name="cheyenne" compiler="gnu" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="pgi" category="prebeta"/>
+      <machine name="derecho" compiler="intel" category="prebeta"/>
     </machines>
   </test>
   <test name="ERS" grid="T62_s11" compset="G" testmods="pop/cice">
@@ -111,30 +105,25 @@
       <machine name="edison" compiler="intel" category="prebeta"/>
     </machines>
   </test>
-  <test name="ERS" grid="T62_g16" compset="G1850ECO" testmods="pop/cice_ecosys">
-    <machines>
-      <machine name="cheyenne" compiler="pgi" category="prealpha"/>
-    </machines>
-  </test>
   <test name="ERS" grid="T62_g37" compset="G1850ECO" testmods="pop/cice_ciso">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
     </machines>
   </test>
   <test name="ERS" grid="T62_g37" compset="G1850ECO" testmods="pop/cice_ecosys_dust_flux_driver">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
     </machines>
   </test>
   <test name="ERS" grid="T62_g37" compset="G1850ECO" testmods="pop/cice_ecosys_ladjust_bury_coeff">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
     </machines>
   </test>
   <test name="ERS" grid="T62_g17" compset="G1850ECOIAF" testmods="pop/cice_ecosys">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_D" grid="f19_g16_rx1" compset="G1850ECO" testmods="pop/cice_ecosys">
@@ -146,156 +135,153 @@
   </test>
   <test name="ERS_E_Lm3" grid="T62_g16" compset="C1850ECO" testmods="pop/default">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_esmf"/>
+      <machine name="derecho" compiler="intel" category="aux_esmf"/>
     </machines>
   </test>
   <test name="ERS_IOP" grid="T62_g16" compset="CIAF" testmods="pop/default">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
-      <machine name="cheyenne" compiler="gnu" category="prebeta"/>
-      <machine name="cheyenne" compiler="pgi" category="prebeta"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
     </machines>
   </test>
   <test name="ERS_IOP" grid="T62_g17" compset="CIAF" testmods="pop/default">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_IOP" grid="T62_s11" compset="G" testmods="pop/cice">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="pgi" category="prebeta"/>
+      <machine name="derecho" compiler="intel" category="prebeta"/>
       <machine name="hobart" compiler="pgi" category="prebeta"/>
     </machines>
   </test>
   <test name="ERS_IOP" grid="T62_g16" compset="GIAF" testmods="pop/default">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
     </machines>
   </test>
   <test name="ERS_Ld3" grid="T62_g37" compset="C1850ECO" testmods="pop/default">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_testsystem"/>
+      <machine name="derecho" compiler="intel" category="aux_testsystem"/>
     </machines>
   </test>
   <test name="ERS_Ld30" grid="T62_g37" compset="C" testmods="pop/default">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld30" grid="T62_g37" compset="C" testmods="pop/abio_dic_dic14">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld30" grid="T62_g37" compset="C" testmods="pop/abio_dic_dic14_transient">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld30" grid="T62_g37" compset="C1850ECO" testmods="pop/ciso_abio_dic_dic14">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld30" grid="T62_g37" compset="C1850ECO" testmods="pop/ecosys">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld30" grid="T62_g37" compset="C1850ECO" testmods="pop/abio_dic_dic14">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld30" grid="T62_g37" compset="C1850ECO" testmods="pop/ciso">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld30" grid="T62_g37" compset="C1850ECO" testmods="pop/ciso_transient">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld30" grid="T62_g37" compset="C1850ECO" testmods="pop/ciso_transient_abio_dic_dic14_transient">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld30" grid="T62_g37" compset="G" testmods="pop/presaero">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld30" grid="T62_g37" compset="G" testmods="pop/abio_dic_dic14_presaero">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld30" grid="T62_g37" compset="G1850ECO" testmods="pop/ecosys">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld30" grid="T62_g37" compset="G1850ECO" testmods="pop/abio_dic_dic14">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld30" grid="T62_g37" compset="G1850ECO" testmods="pop/ciso">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld30" grid="T62_g37" compset="G1850ECO" testmods="pop/ciso_abio_dic_dic14">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld5" grid="T62_g17" compset="G" testmods="pop/5day_tavg">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld5" grid="T62_g17" compset="G1850ECO" testmods="pop/ecosys_5day_tavg">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld5" grid="TL319_g17" compset="GIAF_JRA" testmods="pop/5day_tavg">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld5" grid="TL319_g17" compset="GIAF_JRA-1p3-2016" testmods="pop/5day_tavg">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld5_D" grid="T62_g17" compset="C1850ECO" testmods="pop/ciso">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
     </machines>
   </test>
   <test name="ERS_Ld5_D" grid="T62_g37" compset="C" testmods="pop/abio_dic_dic14_ltavg_NK">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld5_D" grid="T62_g37" compset="C1850ECO" testmods="pop/ciso_abio_dic_dic14">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld5_D" grid="T62_g37" compset="C1850ECO" testmods="pop/ecosys_fixed_PtoC">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
     </machines>
   </test>
   <test name="ERS_Ld5_D" grid="T62_g37" compset="C1850ECO" testmods="pop/ecosys_box_atm_co2">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
     </machines>
   </test>
   <test name="ERS_Ld5_D" grid="T62_g37" compset="C1850ECO" testmods="pop/ecosys">
@@ -305,18 +291,18 @@
   </test>
   <test name="ERS_Ld5_D" grid="T62_g37" compset="G1850ECO" testmods="pop/ciso_abio_dic_dic14">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Ld5_D" grid="T62_g37" compset="G1850ECO" testmods="pop/cice_ciso">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
     </machines>
   </test>
   <test name="ERS_Ld6_D" grid="T62_g37" compset="C1850ECO" testmods="pop/5day_r4_tavg">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
     </machines>
   </test>
   <test name="ERS_Lm3" grid="T62_g16" compset="C" testmods="pop/default">
@@ -326,7 +312,7 @@
   </test>
   <test name="ERS_Lm3" grid="T62_g17" compset="C" testmods="pop/default">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="ERS_Lm3" grid="T62_g16" compset="C1850ECO" testmods="pop/ecosys">
@@ -336,65 +322,54 @@
   </test>
   <test name="ERS_Lm3" grid="T62_g16" compset="CIAF" testmods="pop/default">
     <machines>
-      <machine name="cheyenne" compiler="gnu" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="pgi" category="prebeta"/>
+      <machine name="derecho" compiler="intel" category="prebeta"/>
       <machine name="hobart" compiler="pgi" category="prebeta"/>
     </machines>
   </test>
   <test name="ERS_Lm3" grid="T62_g16" compset="GIAF" testmods="pop/cice">
     <machines>
-      <machine name="cheyenne" compiler="gnu" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="pgi" category="prebeta"/>
-    </machines>
-  </test>
-  <test name="ERS_Lm3" grid="TL319_g17" compset="GIAF_JRA" testmods="pop/cice">
-    <machines>
-      <machine name="cheyenne" compiler="gnu" category="prebeta"/>
+      <machine name="derecho" compiler="intel" category="prebeta"/>
     </machines>
   </test>
   <test name="ERS_Lm3_E" grid="T62_g37" compset="G" testmods="pop/cice">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_esmf"/>
+      <machine name="derecho" compiler="intel" category="aux_esmf"/>
     </machines>
   </test>
   <test name="ICP" grid="T62_g16" compset="G" testmods="pop/cice">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_scripts"/>
+      <machine name="derecho" compiler="intel" category="aux_scripts"/>
     </machines>
   </test>
   <test name="OCP" grid="T62_g16" compset="C1850ECO">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_scripts"/>
+      <machine name="derecho" compiler="intel" category="aux_scripts"/>
     </machines>
   </test>
   <test name="PET" grid="T62_g16" compset="G" testmods="pop/cice">
     <machines>
-      <machine name="cheyenne" compiler="gnu" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="pgi" category="prebeta"/>
+      <machine name="derecho" compiler="intel" category="prebeta"/>
       <machine name="edison" compiler="intel" category="prebeta"/>
     </machines>
   </test>
   <test name="PFS" grid="T62_g16" compset="C">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="csltiming"/>
+      <machine name="derecho" compiler="intel" category="csltiming"/>
     </machines>
   </test>
   <test name="PFS" grid="T62_g16" compset="C1850ECO">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="csltiming"/>
+      <machine name="derecho" compiler="intel" category="csltiming"/>
     </machines>
   </test>
   <test name="PFS" grid="T62_g16" compset="G">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="csltiming"/>
+      <machine name="derecho" compiler="intel" category="csltiming"/>
     </machines>
   </test>
   <test name="PFS" grid="T62_g16" compset="G1850ECO">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="csltiming"/>
+      <machine name="derecho" compiler="intel" category="csltiming"/>
     </machines>
   </test>
   <test name="SBN" grid="T62_t12" compset="C">
@@ -409,65 +384,65 @@
   </test>
   <test name="SMS" grid="T62_g17" compset="C" testmods="pop/default">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="SMS" grid="T62_g17" compset="C" testmods="pop/default_spacecurve">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
-  <test name="SMS" grid="T62_t13" compset="C_HR" testmods="pop/hires_core2_cheyenne">
+  <test name="SMS" grid="T62_t13" compset="C_HR" testmods="pop/hires_core2_derecho">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_tripole"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_tripole"/>
     </machines>
   </test>
-  <test name="SMS" grid="TL319_t13" compset="C_JRA_HR" testmods="pop/hires_jra_cheyenne">
+  <test name="SMS" grid="TL319_t13" compset="C_JRA_HR" testmods="pop/hires_jra_derecho">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_tripole"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_tripole"/>
     </machines>
   </test>
   <test name="SMS" grid="T62_g17" compset="C" testmods="pop/no_cvmix">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="SMS_N2" grid="T62_g17" compset="C1850ECO" testmods="pop/ecosys">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="SMS" grid="T62_g37" compset="C" testmods="pop/default">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cime_baselines"/>
+      <machine name="derecho" compiler="intel" category="aux_cime_baselines"/>
     </machines>
   </test>
   <test name="SMS" grid="T62_g16" compset="C1850ECO" testmods="pop/ecosys">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_drv"/>
+      <machine name="derecho" compiler="intel" category="aux_drv"/>
     </machines>
   </test>
   <test name="SMS" grid="T62_g17" compset="C1850ECO" testmods="pop/ecosys">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_cime_baselines"/>
+      <machine name="derecho" compiler="intel" category="aux_cime_baselines"/>
     </machines>
   </test>
   <test name="SMS" grid="T62_g37" compset="C1850ECO_ECOCESM20" testmods="pop/ecosys">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
       <machine name="hobart" compiler="nag" category="aux_pop_MARBL"/>
     </machines>
   </test>
   <test name="SMS" grid="T62_g17" compset="C1850ECO_ECOCESM20" testmods="pop/ecosys">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
     </machines>
   </test>
   <test name="SMS" grid="T62_g37" compset="C1850ECO" testmods="pop/ecosys_read_fallback_gx3v7">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
       <machine name="hobart" compiler="nag" category="aux_pop_MARBL"/>
     </machines>
   </test>
@@ -494,53 +469,51 @@
   </test>
   <test name="SMS" grid="T62_g17" compset="G1850ECO" testmods="pop/ecosys_daily_r4_tavg">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
     </machines>
   </test>
   <test name="SMS_D" grid="T62_g37" compset="C1850ECO" testmods="pop/ecosys">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
     </machines>
   </test>
   <test name="SMS_D" grid="T62_s11" compset="G" testmods="pop/cice">
     <machines>
-      <machine name="cheyenne" compiler="gnu" category="prebeta"/>
-      <machine name="cheyenne" compiler="intel" category="prebeta"/>
-      <machine name="cheyenne" compiler="pgi" category="prebeta"/>
+      <machine name="derecho" compiler="intel" category="prebeta"/>
     </machines>
   </test>
   <test name="SMS_D" grid="T62_g37" compset="G1850ECO" testmods="pop/ecosys">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="SMS_D" grid="T62_g37" compset="G1850ECO" testmods="pop/cice_ecosys">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
-      <machine name="cheyenne" compiler="intel" category="aux_cime_baselines"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_cime_baselines"/>
     </machines>
   </test>
   <test name="SMS_D_Ld2" grid="TL319_g17" compset="G1850ECOIAF_JRA" testmods="pop/cice_ecosys">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="SMS_D_Ld2" grid="T62_g17" compset="GOMIPECOIAF" testmods="pop/omip">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="SMS_D_Ld2" grid="TL319_g17" compset="GOMIPECOIAF_JRA-1p4-2018" testmods="pop/omip">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="SMS_DE" grid="T62_g16" compset="CIAF" testmods="pop/default">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_esmf"/>
+      <machine name="derecho" compiler="intel" category="aux_esmf"/>
     </machines>
   </test>
   <test name="SMS_Ld2" grid="T62_g37" compset="C1850ECO" testmods="pop/ciso">
@@ -560,18 +533,18 @@
   </test>
   <test name="SMS_Ld20" grid="T62_g17" compset="C" testmods="pop/performance_eval">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
   <test name="SMS_Ld20" grid="T62_g17" compset="G" testmods="pop/performance_eval">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
-      <machine name="cheyenne" compiler="intel" category="aux_cime_baselines"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_cime_baselines"/>
     </machines>
   </test>
   <test name="SMS_Ld2_D" grid="T62_g37" compset="C1850ECO" testmods="pop/ciso_daily_r4_tavg">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
     </machines>
   </test>
   <test name="SMS_Ld2_D" grid="T62_g37" compset="C1850ECO" testmods="pop/ciso">
@@ -581,32 +554,32 @@
   </test>
   <test name="SMS_Ld1_P136_D" grid="T62_g17" compset="C" testmods="pop/144blocks_320x384_spacecurve">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
       <machine name="hobart" compiler="nag" category="prealpha"/>
     </machines>
   </test>
   <test name="SMS_Ld1_P144_D" grid="T62_g17" compset="C" testmods="pop/144blocks_320x384_spacecurve">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
       <machine name="hobart" compiler="nag" category="prealpha"/>
     </machines>
   </test>
   <test name="SMS_Ld2_P72_D" grid="T62_g37" compset="C1850ECO" testmods="pop/ecosys_81blocks_100x116_spacecurve">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
       <machine name="hobart" compiler="nag" category="aux_pop_MARBL"/>
       <machine name="hobart" compiler="nag" category="prealpha"/>
     </machines>
   </test>
   <test name="SMS_Ld2_P80_D" grid="T62_g37" compset="C1850ECO" testmods="pop/ecosys_81blocks_100x116_spacecurve">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
-      <machine name="cheyenne" compiler="intel" category="prealpha"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="prealpha"/>
       <machine name="hobart" compiler="nag" category="aux_pop_MARBL"/>
       <machine name="hobart" compiler="nag" category="prealpha"/>
     </machines>
@@ -618,12 +591,12 @@
   </test>
   <test name="SMS_N2_Ld3_P144x1" grid="T62_g37" compset="C1850ECO" testmods="pop/ecosys_multiinst_lsource_sink">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop_MARBL"/>
+      <machine name="derecho" compiler="intel" category="aux_pop_MARBL"/>
     </machines>
   </test>
   <test name="SMS_P15x1_D" grid="T62_g37" compset="C1850ECO" testmods="pop/ecosys">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_pop"/>
+      <machine name="derecho" compiler="intel" category="aux_pop"/>
     </machines>
   </test>
 </testlist>


### PR DESCRIPTION
### Description of changes:

Added PE layouts for derecho, removed PE layouts for cheyenne, and updated testlist to move `cheyenne_intel` tests to `derecho_intel` and remove all other `cheyenne` tests (`intel` is only supported compiler for 2.1.z). I also updated `generate_pop_decomp.xml` to include a 128 PE layout for the `gx3v7` grid as well as some large PE layouts for `tx0.1v3`.

### Testing:

I ran `aux_pop` and verified that all tests ran successfully. I also did some performance testing, and can report the following throughput in different configurations (from `SMS_Ld20` and `SMS_Ld20_D` tests using the `pop/performance_eval` testmod directory)

| Resolution | C compset | G compset | C1850ECO compset | G1850ECO compset |
| --- |  --- |  --- |  --- |  --- |
| T62_g37 | 530.80 SYPD | 359.77 SYPD | 184.65 SYPD | 196.13 SYPD |
| T62_g17 | 61.26 SYPD | 61.42 SYPD | 29.81 SYPD | 29.70 SYPD |
| T62_g37 (DEBUG) | 62.07 SYPD | 66.60 SYPD | 12.60 SYPD | 12.90 SYPD |
| T62_g17 (DEBUG) | 5.75 SYPD | 5.79 SYPD | 2.44 SYPD | 2.44 SYPD |

The only odd thing from this table is the drop from 530 SYPD -> 360 SYPD in the 3 degree grid when turning CICE on -- for some reason, WW3 is 4x slower in the G compset (despite running on the same number of cores); this is true at both resolutions and whether MARBL tracers are on or off, but POP is so fast on the 3 degree grid without MARBL that WW3 becomes the bottleneck in the G compset. I'll run a series of tests using a smaller number of cores for WW3 and see if it makes a difference before taking this PR out of draft.

Test status: bit-for-bit doesn't make sense in context of adding a new machine

User interface (namelist or namelist defaults) changes? None

