### PR TITLE
replace the depricated given/when structure used in build_namelist

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -2663,25 +2663,25 @@ sub valid_date {
   my $cal = shift;
 
   my $maxday = -1;
-  given ($$month) {
-    when (1) { $maxday = 31; }
-    when (2) {
+  for ($$month) {
+    if (1) { $maxday = 31; }
+    elsif (2) {
       if (($cal eq 'NO_LEAP') || (not leap($$year))) {
         $maxday = 28;
       } else {
         $maxday = 29;
       }
     }
-    when (3) { $maxday = 31; }
-    when (4) { $maxday = 30; }
-    when (5) { $maxday = 31; }
-    when (6) { $maxday = 30; }
-    when (7) { $maxday = 31; }
-    when (8) { $maxday = 31; }
-    when (9) { $maxday = 30; }
-    when (10) { $maxday = 31; }
-    when (11) { $maxday = 30; }
-    when (12) { $maxday = 31; }
+    elsif (3) { $maxday = 31; }
+    elsif (4) { $maxday = 30; }
+    elsif (5) { $maxday = 31; }
+    elsif (6) { $maxday = 30; }
+    elsif (7) { $maxday = 31; }
+    elsif (8) { $maxday = 31; }
+    elsif (9) { $maxday = 30; }
+    elsif (10) { $maxday = 31; }
+    elsif (11) { $maxday = 30; }
+    elsif (12) { $maxday = 31; }
   }
   if ($maxday == -1) {
     die "ERROR: can not figure out what month $$month is";


### PR DESCRIPTION
### Description of changes:

The given/when structure of perl has been depricated.  
this for/if/elsif replacement is needed for newer versions of perl.

### Testing:
 
Test case/suite: aux_pop
Test status: bit for bit

Fixes [POP2 Github issue #]

User interface (namelist or namelist defaults) changes?

